### PR TITLE
🆕キャッシュ機能の追加

### DIFF
--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		715D9A362420854E0018F526 /* StationLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A352420854E0018F526 /* StationLocalCache.swift */; };
 		715D9A38242086C80018F526 /* CollegeLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A37242086C80018F526 /* CollegeLocalCache.swift */; };
 		715D9A3D2420880C0018F526 /* LocalCacheRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */; };
+		715D9A3F2420982D0018F526 /* RealmError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A3E2420982D0018F526 /* RealmError.swift */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -150,6 +151,7 @@
 		715D9A352420854E0018F526 /* StationLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationLocalCache.swift; sourceTree = "<group>"; };
 		715D9A37242086C80018F526 /* CollegeLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegeLocalCache.swift; sourceTree = "<group>"; };
 		715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheRepository.swift; sourceTree = "<group>"; };
+		715D9A3E2420982D0018F526 /* RealmError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmError.swift; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 		715D9A2F242080B60018F526 /* Realm */ = {
 			isa = PBXGroup;
 			children = (
+				715D9A3E2420982D0018F526 /* RealmError.swift */,
 				715D9A30242080C30018F526 /* RealmProvider.swift */,
 			);
 			path = Realm;
@@ -1064,6 +1067,7 @@
 				71536D5A23F16DC1004A330C /* RCPdfUrlEntity.swift in Sources */,
 				715D9A3D2420880C0018F526 /* LocalCacheRepository.swift in Sources */,
 				71A32A6A23E083A000EB7A55 /* FirestoreProvider.swift in Sources */,
+				715D9A3F2420982D0018F526 /* RealmError.swift in Sources */,
 				71A32A5F23E0836500EB7A55 /* FirestoreError.swift in Sources */,
 				715D9A362420854E0018F526 /* StationLocalCache.swift in Sources */,
 				A4AC23AE23E2D7590012439D /* FirestoreRepository.swift in Sources */,

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -219,7 +219,7 @@
 		A4AC23A423E2C1B60012439D /* PdfButtonsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfButtonsViewController.swift; sourceTree = "<group>"; };
 		A4AC23A623E2C1D30012439D /* PdfButtonsViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PdfButtonsViewController.storyboard; sourceTree = "<group>"; };
 		A4AC23AD23E2D7590012439D /* FirestoreRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreRepository.swift; sourceTree = "<group>"; };
-		A4B03E8023DE7CAB0069F7E8 /* 中京大学バス.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "中京大学バス.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A4B03E8023DE7CAB0069F7E8 /* ChukyoBustime.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChukyoBustime.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4B03E8323DE7CAB0069F7E8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A4B03E8C23DE7CB20069F7E8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A4B03E8F23DE7CB20069F7E8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -797,7 +797,7 @@
 		A4B03E8123DE7CAB0069F7E8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A4B03E8023DE7CAB0069F7E8 /* 中京大学バス.app */,
+				A4B03E8023DE7CAB0069F7E8 /* ChukyoBustime.app */,
 				71A329E323E04FB700EB7A55 /* Infra.framework */,
 			);
 			name = Products;
@@ -914,7 +914,7 @@
 			);
 			name = ChukyoBustime;
 			productName = ChukyoBustime;
-			productReference = A4B03E8023DE7CAB0069F7E8 /* 中京大学バス.app */;
+			productReference = A4B03E8023DE7CAB0069F7E8 /* ChukyoBustime.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -1371,7 +1371,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime;
-				PRODUCT_NAME = "中京大学バス";
+				PRODUCT_NAME = ChukyoBustime;
 				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime iOS App Development";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1398,7 +1398,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime;
-				PRODUCT_NAME = "中京大学バス";
+				PRODUCT_NAME = ChukyoBustime;
 				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime iOS App Development";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		71536D7623F4216A004A330C /* SettingItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71536D7423F4216A004A330C /* SettingItemCell.swift */; };
 		71536D7723F4216A004A330C /* SettingItemCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 71536D7523F4216A004A330C /* SettingItemCell.xib */; };
 		71536D7A23F43521004A330C /* SettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71536D7923F43521004A330C /* SettingModel.swift */; };
+		715D9A31242080C30018F526 /* RealmProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A30242080C30018F526 /* RealmProvider.swift */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -140,6 +141,7 @@
 		71536D7423F4216A004A330C /* SettingItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingItemCell.swift; sourceTree = "<group>"; };
 		71536D7523F4216A004A330C /* SettingItemCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingItemCell.xib; sourceTree = "<group>"; };
 		71536D7923F43521004A330C /* SettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingModel.swift; sourceTree = "<group>"; };
+		715D9A30242080C30018F526 /* RealmProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmProvider.swift; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -316,6 +318,14 @@
 			path = Setting;
 			sourceTree = "<group>";
 		};
+		715D9A2F242080B60018F526 /* Realm */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A30242080C30018F526 /* RealmProvider.swift */,
+			);
+			path = Realm;
+			sourceTree = "<group>";
+		};
 		71910BBF23EB100300132A7D /* ToCollege */ = {
 			isa = PBXGroup;
 			children = (
@@ -361,6 +371,7 @@
 		71A32A5D23E0835200EB7A55 /* Provider */ = {
 			isa = PBXGroup;
 			children = (
+				715D9A2F242080B60018F526 /* Realm */,
 				7114165823EE84E600FBFB7E /* RemoteConfig */,
 				A4AC23AA23E2D6AD0012439D /* Firestore */,
 			);
@@ -1027,6 +1038,7 @@
 				A4AC23AE23E2D7590012439D /* FirestoreRepository.swift in Sources */,
 				7114165C23EE95FE00FBFB7E /* RemoteConfigType.swift in Sources */,
 				A42D0DB223E1282B00E95FED /* BusDestination.swift in Sources */,
+				715D9A31242080C30018F526 /* RealmProvider.swift in Sources */,
 				717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */,
 				7114165A23EE904300FBFB7E /* RemoteConfigProvider.swift in Sources */,
 			);

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		71536D7723F4216A004A330C /* SettingItemCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 71536D7523F4216A004A330C /* SettingItemCell.xib */; };
 		71536D7A23F43521004A330C /* SettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71536D7923F43521004A330C /* SettingModel.swift */; };
 		715D9A31242080C30018F526 /* RealmProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A30242080C30018F526 /* RealmProvider.swift */; };
+		715D9A34242082900018F526 /* LocalCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A33242082900018F526 /* LocalCacheable.swift */; };
+		715D9A362420854E0018F526 /* StationLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A352420854E0018F526 /* StationLocalCache.swift */; };
+		715D9A38242086C80018F526 /* CollegeLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A37242086C80018F526 /* CollegeLocalCache.swift */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -142,6 +145,9 @@
 		71536D7523F4216A004A330C /* SettingItemCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingItemCell.xib; sourceTree = "<group>"; };
 		71536D7923F43521004A330C /* SettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingModel.swift; sourceTree = "<group>"; };
 		715D9A30242080C30018F526 /* RealmProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmProvider.swift; sourceTree = "<group>"; };
+		715D9A33242082900018F526 /* LocalCacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheable.swift; sourceTree = "<group>"; };
+		715D9A352420854E0018F526 /* StationLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationLocalCache.swift; sourceTree = "<group>"; };
+		715D9A37242086C80018F526 /* CollegeLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegeLocalCache.swift; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -326,6 +332,16 @@
 			path = Realm;
 			sourceTree = "<group>";
 		};
+		715D9A32242081D10018F526 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A33242082900018F526 /* LocalCacheable.swift */,
+				715D9A352420854E0018F526 /* StationLocalCache.swift */,
+				715D9A37242086C80018F526 /* CollegeLocalCache.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
 		71910BBF23EB100300132A7D /* ToCollege */ = {
 			isa = PBXGroup;
 			children = (
@@ -384,6 +400,7 @@
 				A42D0DA323E112F100E95FED /* Enum */,
 				A42D0DA023E112A100E95FED /* BusDate */,
 				71A32A6C23E083BB00EB7A55 /* BusTime */,
+				715D9A32242081D10018F526 /* Cache */,
 				71536D5423F1614F004A330C /* RCPdfUrl */,
 			);
 			path = Entity;
@@ -1030,12 +1047,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				715D9A38242086C80018F526 /* CollegeLocalCache.swift in Sources */,
 				A42D0DA223E112C400E95FED /* BusDateEntity.swift in Sources */,
 				71A32A6E23E083C800EB7A55 /* BusTimeEntity.swift in Sources */,
 				71536D5A23F16DC1004A330C /* RCPdfUrlEntity.swift in Sources */,
 				71A32A6A23E083A000EB7A55 /* FirestoreProvider.swift in Sources */,
 				71A32A5F23E0836500EB7A55 /* FirestoreError.swift in Sources */,
+				715D9A362420854E0018F526 /* StationLocalCache.swift in Sources */,
 				A4AC23AE23E2D7590012439D /* FirestoreRepository.swift in Sources */,
+				715D9A34242082900018F526 /* LocalCacheable.swift in Sources */,
 				7114165C23EE95FE00FBFB7E /* RemoteConfigType.swift in Sources */,
 				A42D0DB223E1282B00E95FED /* BusDestination.swift in Sources */,
 				715D9A31242080C30018F526 /* RealmProvider.swift in Sources */,

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		715D9A34242082900018F526 /* LocalCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A33242082900018F526 /* LocalCacheable.swift */; };
 		715D9A362420854E0018F526 /* StationLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A352420854E0018F526 /* StationLocalCache.swift */; };
 		715D9A38242086C80018F526 /* CollegeLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A37242086C80018F526 /* CollegeLocalCache.swift */; };
+		715D9A3D2420880C0018F526 /* LocalCacheRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -148,6 +149,7 @@
 		715D9A33242082900018F526 /* LocalCacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheable.swift; sourceTree = "<group>"; };
 		715D9A352420854E0018F526 /* StationLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationLocalCache.swift; sourceTree = "<group>"; };
 		715D9A37242086C80018F526 /* CollegeLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegeLocalCache.swift; sourceTree = "<group>"; };
+		715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheRepository.swift; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -338,6 +340,14 @@
 				715D9A33242082900018F526 /* LocalCacheable.swift */,
 				715D9A352420854E0018F526 /* StationLocalCache.swift */,
 				715D9A37242086C80018F526 /* CollegeLocalCache.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
+		715D9A39242087D00018F526 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */,
 			);
 			path = Cache;
 			sourceTree = "<group>";
@@ -757,6 +767,7 @@
 		A4AC23AB23E2D7320012439D /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				715D9A39242087D00018F526 /* Cache */,
 				A4AC23AC23E2D73C0012439D /* Firestore */,
 			);
 			path = Repository;
@@ -1051,6 +1062,7 @@
 				A42D0DA223E112C400E95FED /* BusDateEntity.swift in Sources */,
 				71A32A6E23E083C800EB7A55 /* BusTimeEntity.swift in Sources */,
 				71536D5A23F16DC1004A330C /* RCPdfUrlEntity.swift in Sources */,
+				715D9A3D2420880C0018F526 /* LocalCacheRepository.swift in Sources */,
 				71A32A6A23E083A000EB7A55 /* FirestoreProvider.swift in Sources */,
 				71A32A5F23E0836500EB7A55 /* FirestoreError.swift in Sources */,
 				715D9A362420854E0018F526 /* StationLocalCache.swift in Sources */,

--- a/ChukyoBustime/Application/Model/ToCollege/ToCollegeModel.swift
+++ b/ChukyoBustime/Application/Model/ToCollege/ToCollegeModel.swift
@@ -45,9 +45,9 @@ class ToCollegeModelImpl: ToCollegeModel {
     }
     
     private func getBusTimesFromCache(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
-        return localCacheRepository.loadCache(of: StationLocalCache.self)
+        return localCacheRepository.loadCache(of: CollegeLocalCache.self)
             .map { (busDate: $0.busDate ?? BusDateEntity(diagram: "UNKNOWN", diagramName: "UNKNOWN"), busTimes: Array($0.busTimes)) }
-            .translate(BusDateAndBusTimesTranslator())
+            .translate(BusDateAndBusTimesTranslator()).debug()
     }
     
     private func getBusTimesFromFirestore(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {

--- a/ChukyoBustime/Application/Model/ToCollege/ToCollegeModel.swift
+++ b/ChukyoBustime/Application/Model/ToCollege/ToCollegeModel.swift
@@ -23,17 +23,40 @@ class ToCollegeModelImpl: ToCollegeModel {
     // MARK: Dependency
     
     private let firestoreRepository: FirestoreRepository
+    private let localCacheRepository: LocalCacheRepository
     
     // MARK: Initializer
     
-    init(firestoreRepository: FirestoreRepository = FirestoreRepositoryImpl()) {
+    init(firestoreRepository: FirestoreRepository = FirestoreRepositoryImpl(),
+         localCacheRepository: LocalCacheRepository = LocalCacheRepositoryImpl()) {
         self.firestoreRepository = firestoreRepository
+        self.localCacheRepository = localCacheRepository
     }
     
     // MARK: Firestore
     
+    /// 時刻表のデータをキャッシュもしくはFirestoreから取得する.
+    /// - Parameter date: 取得するタイミングの`Date`.
     func getBusTimes(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
-        return firestoreRepository.getBusTimes(at: date, destination: .toCollege)
+        return localCacheRepository.checkCache(at: date, destination: .toCollege)
+            .flatMap {
+                $0 ? self.getBusTimesFromCache(at: date) : self.getBusTimesFromFirestore(at: date)
+            }
+    }
+    
+    private func getBusTimesFromCache(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
+        return localCacheRepository.loadCache(of: StationLocalCache.self)
+            .map { (busDate: $0.busDate ?? BusDateEntity(diagram: "UNKNOWN", diagramName: "UNKNOWN"), busTimes: Array($0.busTimes)) }
             .translate(BusDateAndBusTimesTranslator())
+    }
+    
+    private func getBusTimesFromFirestore(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
+        return firestoreRepository.getBusTimes(at: date, destination: .toCollege)
+            .flatMap { value -> Single<(busDate: BusDate, busTimes: [BusTime])> in
+                // NOTE: キャッシュを保存して完了した後にFirestoreから取得したものを流す.
+                return self.localCacheRepository.saveCache(of: .toCollege, date: date, busDate: value.busDate, busTimes: value.busTimes)
+                    .andThen(Single.just((busDate: value.busDate, busTimes: value.busTimes)))
+                    .translate(BusDateAndBusTimesTranslator())
+            }
     }
 }

--- a/ChukyoBustime/Application/Model/ToStation/ToStationModel.swift
+++ b/ChukyoBustime/Application/Model/ToStation/ToStationModel.swift
@@ -23,15 +23,40 @@ class ToStationModelImpl: ToStationModel {
     // MARK: Dependency
     
     private let firestoreRepository: FirestoreRepository
+    private let localCacheRepository: LocalCacheRepository
     
     // MARK: Initializer
     
-    init(firestoreRepository: FirestoreRepository = FirestoreRepositoryImpl()) {
+    init(firestoreRepository: FirestoreRepository = FirestoreRepositoryImpl(),
+         localCacheRepository: LocalCacheRepository = LocalCacheRepositoryImpl()) {
         self.firestoreRepository = firestoreRepository
+        self.localCacheRepository = localCacheRepository
     }
     
+    // MARK: Firestore
+    
+    /// 時刻表のデータをキャッシュもしくはFirestoreから取得する.
+    /// - Parameter date: 取得するタイミングの`Date`.
     func getBusTimes(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
+        return localCacheRepository.checkCache(at: date, destination: .toStation)
+            .flatMap {
+                $0 ? self.getBusTimesFromCache(at: date) : self.getBusTimesFromFirestore(at: date)
+            }
+    }
+    
+    private func getBusTimesFromCache(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
+        return localCacheRepository.loadCache(of: StationLocalCache.self)
+            .map { (busDate: $0.busDate ?? BusDateEntity(diagram: "UNKNOWN", diagramName: "UNKNOWN"), busTimes: Array($0.busTimes)) }
+            .translate(BusDateAndBusTimesTranslator()).debug()
+    }
+    
+    private func getBusTimesFromFirestore(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
         return firestoreRepository.getBusTimes(at: date, destination: .toStation)
-            .translate(BusDateAndBusTimesTranslator())
+            .flatMap { value -> Single<(busDate: BusDate, busTimes: [BusTime])> in
+                // NOTE: キャッシュを保存して完了した後にFirestoreから取得したものを流す.
+                return self.localCacheRepository.saveCache(of: .toStation, date: date, busDate: value.busDate, busTimes: value.busTimes)
+                    .andThen(Single.just((busDate: value.busDate, busTimes: value.busTimes)))
+                    .translate(BusDateAndBusTimesTranslator())
+            }
     }
 }

--- a/ChukyoBustime/Info.plist
+++ b/ChukyoBustime/Info.plist
@@ -12,6 +12,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>中京大学バス</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>

--- a/Infra/Entity/BusDate/BusDateEntity.swift
+++ b/Infra/Entity/BusDate/BusDateEntity.swift
@@ -18,7 +18,7 @@ public final class BusDateEntity: Object, Decodable {
         case diagramName
     }
     
-    convenience init(diagram: String, diagramName: String) {
+    public convenience init(diagram: String, diagramName: String) {
         self.init()
         self.diagram = diagram
         self.diagramName = diagramName

--- a/Infra/Entity/BusDate/BusDateEntity.swift
+++ b/Infra/Entity/BusDate/BusDateEntity.swift
@@ -7,13 +7,24 @@
 //
 
 import Foundation
+import RealmSwift
 
-public struct BusDateEntity: Decodable {
-    public let diagram: String
-    public let diagramName: String
+public final class BusDateEntity: Object, Decodable {
+    @objc public dynamic var diagram: String = ""
+    @objc public dynamic var diagramName: String = ""
     
     private enum CodingKeys: String, CodingKey {
         case diagram
         case diagramName
+    }
+    
+    convenience init(diagram: String, diagramName: String) {
+        self.init()
+        self.diagram = diagram
+        self.diagramName = diagramName
+    }
+    
+    public required init() {
+        super.init()
     }
 }

--- a/Infra/Entity/BusTime/BusTimeEntity.swift
+++ b/Infra/Entity/BusTime/BusTimeEntity.swift
@@ -7,16 +7,17 @@
 //
 
 import Foundation
+import RealmSwift
 
-public struct BusTimeEntity: Decodable {
-    public let hour: Int
-    public let minute: Int
-    public let second: Int
-    public let arrivalHour: Int
-    public let arrivalMinute: Int
-    public let arrivalSecond: Int
-    public let isReturn: Bool
-    public let isLast: Bool
+public final class BusTimeEntity: Object, Decodable {
+    @objc public dynamic var hour: Int = 0
+    @objc public dynamic var minute: Int = 0
+    @objc public dynamic var second: Int = 0
+    @objc public dynamic var arrivalHour: Int = 0
+    @objc public dynamic var arrivalMinute: Int = 0
+    @objc public dynamic var arrivalSecond: Int = 0
+    @objc public dynamic var isReturn: Bool = false
+    @objc public dynamic var isLast: Bool = false
     
     private enum CodingKeys: String, CodingKey {
         case hour
@@ -27,5 +28,28 @@ public struct BusTimeEntity: Decodable {
         case arrivalSecond
         case isReturn
         case isLast
+    }
+    
+    convenience init(hour: Int,
+                     minute: Int,
+                     second: Int,
+                     arrivalHour: Int,
+                     arrivalMinute: Int,
+                     arrivalSecond: Int,
+                     isReturn: Bool,
+                     isLast: Bool) {
+        self.init()
+        self.hour = hour
+        self.minute = minute
+        self.second = second
+        self.arrivalHour = arrivalHour
+        self.arrivalMinute = arrivalMinute
+        self.arrivalSecond = arrivalSecond
+        self.isReturn = isReturn
+        self.isLast = isLast
+    }
+    
+    public required init() {
+        super.init()
     }
 }

--- a/Infra/Entity/BusTime/BusTimeEntity.swift
+++ b/Infra/Entity/BusTime/BusTimeEntity.swift
@@ -30,14 +30,14 @@ public final class BusTimeEntity: Object, Decodable {
         case isLast
     }
     
-    convenience init(hour: Int,
-                     minute: Int,
-                     second: Int,
-                     arrivalHour: Int,
-                     arrivalMinute: Int,
-                     arrivalSecond: Int,
-                     isReturn: Bool,
-                     isLast: Bool) {
+    public convenience init(hour: Int,
+                            minute: Int,
+                            second: Int,
+                            arrivalHour: Int,
+                            arrivalMinute: Int,
+                            arrivalSecond: Int,
+                            isReturn: Bool,
+                            isLast: Bool) {
         self.init()
         self.hour = hour
         self.minute = minute

--- a/Infra/Entity/Cache/CollegeLocalCache.swift
+++ b/Infra/Entity/Cache/CollegeLocalCache.swift
@@ -1,0 +1,27 @@
+//
+//  CollegeLocalCache.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+public final class CollegeLocalCache: Object, LocalCacheable {
+    @objc public dynamic var lastUpdatedDate: String = "" // YYYY-MM-dd
+    @objc public dynamic var busDate: BusDateEntity?
+    var busTimes = List<BusTimeEntity>()
+    
+    convenience init(lastUpdatedDate: String, busDate: BusDateEntity, busTimes: [BusTimeEntity]) {
+        self.init()
+        self.lastUpdatedDate = lastUpdatedDate
+        self.busDate = busDate
+        self.busTimes = busTimes.reduce(List<BusTimeEntity>()) { $0.append($1); return $0 }
+    }
+    
+    public required init() {
+        super.init()
+    }
+}

--- a/Infra/Entity/Cache/CollegeLocalCache.swift
+++ b/Infra/Entity/Cache/CollegeLocalCache.swift
@@ -12,7 +12,7 @@ import RealmSwift
 public final class CollegeLocalCache: Object, LocalCacheable {
     @objc public dynamic var lastUpdatedDate: String = "" // YYYY-MM-dd
     @objc public dynamic var busDate: BusDateEntity?
-    var busTimes = List<BusTimeEntity>()
+    public var busTimes = List<BusTimeEntity>()
     
     convenience init(lastUpdatedDate: String, busDate: BusDateEntity, busTimes: [BusTimeEntity]) {
         self.init()

--- a/Infra/Entity/Cache/CollegeLocalCache.swift
+++ b/Infra/Entity/Cache/CollegeLocalCache.swift
@@ -21,7 +21,7 @@ public final class CollegeLocalCache: Object, LocalCacheable {
         self.busTimes = busTimes.reduce(List<BusTimeEntity>()) { $0.append($1); return $0 }
     }
     
-    public required init() {
+    required init() {
         super.init()
     }
 }

--- a/Infra/Entity/Cache/LocalCacheable.swift
+++ b/Infra/Entity/Cache/LocalCacheable.swift
@@ -1,0 +1,11 @@
+//
+//  LocalCacheable.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+
+protocol LocalCacheable: AnyObject {}

--- a/Infra/Entity/Cache/LocalCacheable.swift
+++ b/Infra/Entity/Cache/LocalCacheable.swift
@@ -8,4 +8,4 @@
 
 import Foundation
 
-protocol LocalCacheable: AnyObject {}
+public protocol LocalCacheable: AnyObject {}

--- a/Infra/Entity/Cache/StationLocalCache.swift
+++ b/Infra/Entity/Cache/StationLocalCache.swift
@@ -1,0 +1,27 @@
+//
+//  StationLocalCache.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+public final class StationLocalCache: Object, LocalCacheable {
+    @objc public dynamic var lastUpdatedDate: String = "" // YYYY-MM-dd
+    @objc public dynamic var busDate: BusDateEntity?
+    var busTimes = List<BusTimeEntity>()
+    
+    convenience init(lastUpdatedDate: String, busDate: BusDateEntity, busTimes: [BusTimeEntity]) {
+        self.init()
+        self.lastUpdatedDate = lastUpdatedDate
+        self.busDate = busDate
+        self.busTimes = busTimes.reduce(List<BusTimeEntity>()) { $0.append($1); return $0 }
+    }
+    
+    public required init() {
+        super.init()
+    }
+}

--- a/Infra/Entity/Cache/StationLocalCache.swift
+++ b/Infra/Entity/Cache/StationLocalCache.swift
@@ -12,7 +12,7 @@ import RealmSwift
 public final class StationLocalCache: Object, LocalCacheable {
     @objc public dynamic var lastUpdatedDate: String = "" // YYYY-MM-dd
     @objc public dynamic var busDate: BusDateEntity?
-    var busTimes = List<BusTimeEntity>()
+    public var busTimes = List<BusTimeEntity>()
     
     convenience init(lastUpdatedDate: String, busDate: BusDateEntity, busTimes: [BusTimeEntity]) {
         self.init()

--- a/Infra/Entity/Cache/StationLocalCache.swift
+++ b/Infra/Entity/Cache/StationLocalCache.swift
@@ -21,7 +21,7 @@ public final class StationLocalCache: Object, LocalCacheable {
         self.busTimes = busTimes.reduce(List<BusTimeEntity>()) { $0.append($1); return $0 }
     }
     
-    public required init() {
+    required init() {
         super.init()
     }
 }

--- a/Infra/Provider/Realm/RealmError.swift
+++ b/Infra/Provider/Realm/RealmError.swift
@@ -1,0 +1,21 @@
+//
+//  RealmError.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+
+enum RealmError: Error {
+    case objectNotFound
+}
+
+extension RealmError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .objectNotFound: return "データベースに保存されたデータがありません"
+        }
+    }
+}

--- a/Infra/Provider/Realm/RealmProvider.swift
+++ b/Infra/Provider/Realm/RealmProvider.swift
@@ -1,0 +1,245 @@
+//
+//  RealmProvider.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import RxSwift
+
+// MARK: - Interface
+public protocol RealmProviderProtocol: AnyObject {
+    func save<O: Object>(_ object: O) -> Completable
+    func save<O: Object>(overwrite object: O) -> Completable
+    func save<S: Sequence>(_ objects: S) -> Completable where S.Element: Object
+    func save<S: Sequence>(overwrite objects: S) -> Completable where S.Element: Object
+    func get<O: Object>(_ type: O.Type) -> Single<O?>
+    func get<O: Object>(_ type: O.Type) -> Single<[O]>
+    func delete<O: Object>(_ object: O) -> Completable
+    func delete<S: Sequence>(_ objects: S) -> Completable where S.Element: Object
+    func deleteAll<O: Object>(_ type: O.Type) -> Completable
+    func deleteAll() -> Completable
+}
+
+// MARK: - Implementation
+public final class RealmProvider: RealmProviderProtocol {
+    
+    // MARK: Singleton
+    
+    public static let shared: RealmProvider = .init()
+    
+    // MARK: Properties
+    
+    private let realm: Realm
+    private static let schemaVersion: UInt64 = 1
+    
+    // MARK: Initializer
+    
+    private init() {
+        RealmProvider.migrateIfNeeded()
+        
+        do {
+            realm = try Realm()
+            #if DEBUG
+            print(realm.configuration.fileURL ?? "nil")
+            #endif
+        } catch {
+            fatalError("Could not instantiate Realm: \(error)")
+        }
+    }
+    
+    // MARK: Private
+    
+    private static func migrateIfNeeded() {
+        let config = Realm.Configuration(schemaVersion: schemaVersion,
+                                         deleteRealmIfMigrationNeeded: true)
+        Realm.Configuration.defaultConfiguration = config
+    }
+    
+    // MARK: Save
+    
+    /// Realmに保存のみ行う.
+    ///
+    /// - Parameter object: 保存したいObjectクラスを継承したクラス
+    public func save<O: Object>(_ object: O) -> Completable {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                try realm.write {
+                    realm.add(object)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// Realmに全体上書きで保存する( Updateではないので注意 )
+    ///
+    /// - Parameter object: 上書き保存したいObjectクラスを継承したクラス
+    public func save<O: Object>(overwrite object: O) -> Completable {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                let stored = realm.objects(O.self)
+                try realm.write {
+                    realm.delete(stored)
+                    realm.add(object)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    /// Realmに保存のみ行う.
+    ///
+    /// - Parameter objects: 保存したいObjectクラスの配列
+    public func save<S: Sequence>(_ objects: S) -> Completable where S.Element: Object {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                try realm.write {
+                    realm.add(objects)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    /// Realmに全体上書きで保存する( Updateではないので注意 )
+    ///
+    /// - Parameter objects: 上書き保存したいObjectクラスの配列
+    public func save<S: Sequence>(overwrite objects: S) -> Completable where S.Element: Object {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                let stored = realm.objects(S.Element.self)
+                try realm.write {
+                    realm.delete(stored)
+                    realm.add(objects)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    // MARK: Get
+    /// Realmに保存されているオブジェクトの最新一件を取り出す
+    ///
+    /// - Parameter type: 読み込みたいObjectクラスを継承したクラスの型
+    public func get<O: Object>(_ type: O.Type) -> Single<O?> {
+        return Single.create { observer in
+            do {
+                let realm = try Realm()
+                let stored = realm.objects(type).first
+                observer(.success(stored))
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    /// Realmに保存されているオブジェクトを全て取り出す
+    ///
+    /// - Parameter type: 読み込みたいObjectクラスを継承したクラスの型
+    public func get<O: Object>(_ type: O.Type) -> Single<[O]> {
+        return Single.create { observer in
+            do {
+                let realm = try Realm()
+                let stored = Array(realm.objects(type))
+                observer(.success(stored))
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    // MARK: Delete
+    
+    /// 指定したオブジェクトを削除する.
+    ///
+    /// - Parameter object: 削除したい`Object`クラスを継承したオブジェクト.
+    public func delete<O: Object>(_ object: O) -> Completable {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                try realm.write {
+                    realm.delete(object)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+    
+    /// 指定したオブジェクト群を削除する.
+    ///
+    /// - Parameter objects: 削除したい`Object`が要素となる配列.
+    public func delete<S: Sequence>(_ objects: S) -> Completable where S.Element: Object {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                try realm.write {
+                    realm.delete(objects)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// 指定したクラスをRealmから全て削除する
+    ///
+    /// - Parameter type: 削除したいObjectクラスを継承したクラスの型
+    public func deleteAll<O: Object>(_ type: O.Type) -> Completable {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                let objects = realm.objects(type)
+                try realm.write {
+                    realm.delete(objects)
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// Realmに保存されているオブジェクトを全て削除する
+    public func deleteAll() -> Completable {
+        return Completable.create { observer in
+            do {
+                let realm = try Realm()
+                try realm.write {
+                    realm.deleteAll()
+                }
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/Infra/Provider/Realm/RealmProvider.swift
+++ b/Infra/Provider/Realm/RealmProvider.swift
@@ -18,7 +18,7 @@ public protocol RealmProviderProtocol: AnyObject {
     func save<S: Sequence>(_ objects: S) -> Completable where S.Element: Object
     func save<S: Sequence>(overwrite objects: S) -> Completable where S.Element: Object
     func get<O: Object>(_ type: O.Type) -> Single<O?>
-    func get<O: Object>(_ type: O.Type) -> Single<[O]>
+    func getAll<O: Object>(_ type: O.Type) -> Single<[O]>
     func delete<O: Object>(_ object: O) -> Completable
     func delete<S: Sequence>(_ objects: S) -> Completable where S.Element: Object
     func deleteAll<O: Object>(_ type: O.Type) -> Completable
@@ -159,7 +159,7 @@ public final class RealmProvider: RealmProviderProtocol {
     /// Realmに保存されているオブジェクトを全て取り出す
     ///
     /// - Parameter type: 読み込みたいObjectクラスを継承したクラスの型
-    public func get<O: Object>(_ type: O.Type) -> Single<[O]> {
+    public func getAll<O: Object>(_ type: O.Type) -> Single<[O]> {
         return Single.create { observer in
             do {
                 let realm = try Realm()

--- a/Infra/Provider/Realm/RealmProvider.swift
+++ b/Infra/Provider/Realm/RealmProvider.swift
@@ -11,6 +11,7 @@ import RealmSwift
 import RxSwift
 
 // MARK: - Interface
+
 public protocol RealmProviderProtocol: AnyObject {
     func save<O: Object>(_ object: O) -> Completable
     func save<O: Object>(overwrite object: O) -> Completable
@@ -25,6 +26,7 @@ public protocol RealmProviderProtocol: AnyObject {
 }
 
 // MARK: - Implementation
+
 public final class RealmProvider: RealmProviderProtocol {
     
     // MARK: Singleton

--- a/Infra/Repository/Cache/LocalCacheRepository.swift
+++ b/Infra/Repository/Cache/LocalCacheRepository.swift
@@ -1,0 +1,117 @@
+//
+//  LocalCacheRepository.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import SwiftDate
+import RxSwift
+
+// MARK: - Interface
+
+public protocol LocalCacheRepository {
+    
+}
+
+// MARK: - Implementation
+
+public struct LocalCacheRepositoryImpl: LocalCacheRepository {
+    
+    // MARK: Dependency
+    
+    private let provider: RealmProviderProtocol
+    
+    // MARK: Initializer
+    
+    public init(provider: RealmProviderProtocol = RealmProvider.shared) {
+        self.provider = provider
+    }
+    
+    // MARK: Save cache
+    
+    public func saveLocalCache(of destination: BusDestination, date: Date, busDate: BusDateEntity, busTimes: [BusTimeEntity]) -> Completable {
+        return destination == BusDestination.toStation
+            ? overwriteStationLocalCache(date: date, busDate: busDate, busTimes: busTimes)
+            : overwriteCollegeLocalCache(date: date, busDate: busDate, busTimes: busTimes)
+    }
+    
+    /// Realmに保存されている駅行きの時間データのキャッシュを上書きする.
+    /// - Note: 既に保存されていない場合は新しく保存、既に保存されている場合は削除してから新規に保存.
+    /// - Parameters:
+    ///   - date: 保存を行ったタイミングの`Date`.
+    ///   - busDate: 保存する`BusDateEntity`のオブジェクト.
+    ///   - busTimes: 保存する`BusTimeEntity`のオブジェクト配列.
+    private func overwriteStationLocalCache(date: Date, busDate: BusDateEntity, busTimes: [BusTimeEntity]) -> Completable {
+        return provider.get(StationLocalCache.self)
+            .flatMapCompletable { object -> Completable in
+                // NOTE: 既にキャッシュを保存済みかどうかをチェック、正しくリレーションされているかどうかも確認
+                let newCache = StationLocalCache(lastUpdatedDate: date.toFormat("YYYY-MM-dd"), busDate: busDate, busTimes: busTimes)
+                guard let object = object,
+                    let relatedBusDate = object.busDate else {
+                    return self.provider.save(newCache)
+                }
+                // NOTE: 保存されていたオブジェクトを削除してから新規保存
+                return Completable.concat([self.provider.delete(relatedBusDate),
+                                           self.provider.delete(object.busTimes),
+                                           self.provider.delete(object),
+                                           self.provider.save(newCache)])
+        }
+    }
+    
+    /// Realmに保存されている大学行きの時間データのキャッシュを上書きする.
+    /// - Note: 既に保存されていない場合は新しく保存、既に保存されている場合は削除してから新規に保存.
+    /// - Parameters:
+    ///   - date: 保存を行ったタイミングの`Date`.
+    ///   - busDate: 保存する`BusDateEntity`のオブジェクト.
+    ///   - busTimes: 保存する`BusTimeEntity`のオブジェクト配列.
+    private func overwriteCollegeLocalCache(date: Date, busDate: BusDateEntity, busTimes: [BusTimeEntity]) -> Completable {
+        return provider.get(CollegeLocalCache.self)
+            .flatMapCompletable { object -> Completable in
+                // NOTE: 既にキャッシュを保存済みかどうかをチェック、正しくリレーションされているかどうかも確認
+                let newCache = CollegeLocalCache(lastUpdatedDate: date.toFormat("YYYY-MM-dd"), busDate: busDate, busTimes: busTimes)
+                guard let object = object,
+                    let relatedBusDate = object.busDate else {
+                        return self.provider.save(newCache)
+                }
+                // NOTE: 保存されていたオブジェクトを削除してから新規保存
+                return Completable.concat([self.provider.delete(relatedBusDate),
+                                           self.provider.delete(object.busTimes),
+                                           self.provider.delete(object),
+                                           self.provider.save(newCache)])
+        }
+    }
+    
+    // MARK: Check cache
+    
+    public func checkCache(at date: Date, destination: BusDestination) -> Single<Bool> {
+        return destination == BusDestination.toStation
+            ? checkStationLocalCache(at: date)
+            : checkCollegeLocalCache(at: date)
+    }
+    
+    private func checkStationLocalCache(at date: Date) -> Single<Bool> {
+        return provider.get(StationLocalCache.self)
+            .map { object -> Bool in
+                guard let object = object else { return false }
+                return object.lastUpdatedDate == date.toFormat("YYYY-MM-dd")
+            }
+    }
+    
+    private func checkCollegeLocalCache(at date: Date) -> Single<Bool> {
+        return provider.get(CollegeLocalCache.self)
+            .map { object -> Bool in
+                guard let object = object else { return false }
+                return object.lastUpdatedDate == date.toFormat("YYYY-MM-dd")
+            }
+    }
+    
+    // MARK: Load cache
+    
+    func loadCache<O: Object>(of type: O.Type) -> Single<O?> where O: LocalCacheable {
+        return provider.get(type)
+    }
+}


### PR DESCRIPTION
## 📝 Detail  
Firestoreからのフェッチ回数の節約  
App Extensionからの取得に備えてフェッチしたデータをRealmでキャッシュとして持つような処理を追加.
それに伴い必要な`Entity`を追加、修正.

またXcode11で `Could not hardlink copy`と言うエラーが発生したので  
以下の対応を実行. ( [参考](https://qiita.com/kouchi67/items/bad83f73afdb84210bb4) )

- Xcode側の`Display Name`を日本語から英語に修正( コピーに失敗するため )
- 代わりに`Info.plist`の`Display Name`を利用してアプリ名を指定.