### PR TITLE
🆕 ウィジェット( Today Extension )を追加

### DIFF
--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -28,6 +28,15 @@
 		715D9A38242086C80018F526 /* CollegeLocalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A37242086C80018F526 /* CollegeLocalCache.swift */; };
 		715D9A3D2420880C0018F526 /* LocalCacheRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */; };
 		715D9A3F2420982D0018F526 /* RealmError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A3E2420982D0018F526 /* RealmError.swift */; };
+		715D9A472420A8ED0018F526 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 715D9A462420A8ED0018F526 /* NotificationCenter.framework */; };
+		715D9A4A2420A8ED0018F526 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A492420A8ED0018F526 /* TodayViewController.swift */; };
+		715D9A4D2420A8ED0018F526 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 715D9A4B2420A8ED0018F526 /* MainInterface.storyboard */; };
+		715D9A512420A8ED0018F526 /* Today.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 715D9A452420A8ED0018F526 /* Today.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		715D9A5B2420AA400018F526 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B03F0223DE8B130069F7E8 /* RxCocoa.framework */; };
+		715D9A5C2420AA400018F526 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B03F0123DE8B130069F7E8 /* RxRelay.framework */; };
+		715D9A5D2420AA400018F526 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B03EFD23DE8A960069F7E8 /* RxSwift.framework */; };
+		715D9A5E2420AA630018F526 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B4241F0E280087B373 /* Realm.framework */; };
+		715D9A602420AA630018F526 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B3241F0E280087B373 /* RealmSwift.framework */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -107,6 +116,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		715D9A4F2420A8ED0018F526 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A4B03E7823DE7CAB0069F7E8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 715D9A442420A8ED0018F526;
+			remoteInfo = Today;
+		};
 		71A329E823E04FB700EB7A55 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A4B03E7823DE7CAB0069F7E8 /* Project object */;
@@ -117,6 +133,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		715D9A522420A8ED0018F526 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				715D9A512420A8ED0018F526 /* Today.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A4B03EF023DE861E0069F7E8 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -152,6 +179,11 @@
 		715D9A37242086C80018F526 /* CollegeLocalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegeLocalCache.swift; sourceTree = "<group>"; };
 		715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheRepository.swift; sourceTree = "<group>"; };
 		715D9A3E2420982D0018F526 /* RealmError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmError.swift; sourceTree = "<group>"; };
+		715D9A452420A8ED0018F526 /* Today.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Today.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		715D9A462420A8ED0018F526 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		715D9A492420A8ED0018F526 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
+		715D9A4C2420A8ED0018F526 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		715D9A4E2420A8ED0018F526 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -234,14 +266,27 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		715D9A422420A8ED0018F526 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				715D9A5B2420AA400018F526 /* RxCocoa.framework in Frameworks */,
+				715D9A5C2420AA400018F526 /* RxRelay.framework in Frameworks */,
+				715D9A5D2420AA400018F526 /* RxSwift.framework in Frameworks */,
+				715D9A472420A8ED0018F526 /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		71A329E023E04FB700EB7A55 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				71A32A6223E0838600EB7A55 /* RxRelay.framework in Frameworks */,
 				71A32A6023E0838600EB7A55 /* RxCocoa.framework in Frameworks */,
+				715D9A602420AA630018F526 /* RealmSwift.framework in Frameworks */,
 				71A32A6623E0838600EB7A55 /* SwiftDate.framework in Frameworks */,
 				71A32A6423E0838600EB7A55 /* RxSwift.framework in Frameworks */,
+				715D9A5E2420AA630018F526 /* Realm.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -353,6 +398,40 @@
 				715D9A3C2420880C0018F526 /* LocalCacheRepository.swift */,
 			);
 			path = Cache;
+			sourceTree = "<group>";
+		};
+		715D9A482420A8ED0018F526 /* Today */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A562420A91F0018F526 /* Application */,
+				715D9A582420A9460018F526 /* Configs */,
+				715D9A4E2420A8ED0018F526 /* Info.plist */,
+			);
+			path = Today;
+			sourceTree = "<group>";
+		};
+		715D9A562420A91F0018F526 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A572420A9360018F526 /* View */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		715D9A572420A9360018F526 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A492420A8ED0018F526 /* TodayViewController.swift */,
+				715D9A4B2420A8ED0018F526 /* MainInterface.storyboard */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		715D9A582420A9460018F526 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Configs;
 			sourceTree = "<group>";
 		};
 		71910BBF23EB100300132A7D /* ToCollege */ = {
@@ -789,6 +868,7 @@
 			children = (
 				A4B03E8223DE7CAB0069F7E8 /* ChukyoBustime */,
 				71A329E423E04FB700EB7A55 /* Infra */,
+				715D9A482420A8ED0018F526 /* Today */,
 				A4B03E8123DE7CAB0069F7E8 /* Products */,
 				A4B03EFC23DE8A960069F7E8 /* Frameworks */,
 			);
@@ -799,6 +879,7 @@
 			children = (
 				A4B03E8023DE7CAB0069F7E8 /* ChukyoBustime.app */,
 				71A329E323E04FB700EB7A55 /* Infra.framework */,
+				715D9A452420A8ED0018F526 /* Today.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -851,6 +932,7 @@
 				A4B03F0223DE8B130069F7E8 /* RxCocoa.framework */,
 				A4B03F0123DE8B130069F7E8 /* RxRelay.framework */,
 				A4B03EFD23DE8A960069F7E8 /* RxSwift.framework */,
+				715D9A462420A8ED0018F526 /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -877,6 +959,23 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		715D9A442420A8ED0018F526 /* Today */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 715D9A552420A8ED0018F526 /* Build configuration list for PBXNativeTarget "Today" */;
+			buildPhases = (
+				715D9A412420A8ED0018F526 /* Sources */,
+				715D9A422420A8ED0018F526 /* Frameworks */,
+				715D9A432420A8ED0018F526 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Today;
+			productName = Today;
+			productReference = 715D9A452420A8ED0018F526 /* Today.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		71A329E223E04FB700EB7A55 /* Infra */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 71A329EE23E04FB700EB7A55 /* Build configuration list for PBXNativeTarget "Infra" */;
@@ -906,11 +1005,13 @@
 				71A32A5923E05DA400EB7A55 /* Copy Dynamic Frameworks */,
 				A4B03F0823DE8B240069F7E8 /* Carthage */,
 				71FF5C1D23E1E8B400456D75 /* Crashlytics */,
+				715D9A522420A8ED0018F526 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				71A329E923E04FB700EB7A55 /* PBXTargetDependency */,
+				715D9A502420A8ED0018F526 /* PBXTargetDependency */,
 			);
 			name = ChukyoBustime;
 			productName = ChukyoBustime;
@@ -927,6 +1028,9 @@
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Shunya Yamada";
 				TargetAttributes = {
+					715D9A442420A8ED0018F526 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
 					71A329E223E04FB700EB7A55 = {
 						CreatedOnToolsVersion = 11.3.1;
 						LastSwiftMigration = 1130;
@@ -952,11 +1056,20 @@
 			targets = (
 				A4B03E7F23DE7CAB0069F7E8 /* ChukyoBustime */,
 				71A329E223E04FB700EB7A55 /* Infra */,
+				715D9A442420A8ED0018F526 /* Today */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		715D9A432420A8ED0018F526 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				715D9A4D2420A8ED0018F526 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		71A329E123E04FB700EB7A55 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1057,6 +1170,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		715D9A412420A8ED0018F526 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				715D9A4A2420A8ED0018F526 /* TodayViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		71A329DF23E04FB700EB7A55 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1140,6 +1261,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		715D9A502420A8ED0018F526 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 715D9A442420A8ED0018F526 /* Today */;
+			targetProxy = 715D9A4F2420A8ED0018F526 /* PBXContainerItemProxy */;
+		};
 		71A329E923E04FB700EB7A55 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 71A329E223E04FB700EB7A55 /* Infra */;
@@ -1148,6 +1274,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		715D9A4B2420A8ED0018F526 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				715D9A4C2420A8ED0018F526 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		A4B03E8E23DE7CB20069F7E8 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -1160,6 +1294,57 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		715D9A532420A8ED0018F526 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 7NJH5NAV4T;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Today/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		715D9A542420A8ED0018F526 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7NJH5NAV4T;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Today/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		71A329EC23E04FB700EB7A55 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71A32A5723E057E900EB7A55 /* Infra-Config.debug.xcconfig */;
@@ -1408,6 +1593,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		715D9A552420A8ED0018F526 /* Build configuration list for PBXNativeTarget "Today" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				715D9A532420A8ED0018F526 /* Debug */,
+				715D9A542420A8ED0018F526 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		71A329EE23E04FB700EB7A55 /* Build configuration list for PBXNativeTarget "Infra" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		71059428241A251D003CA820 /* OutlinedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71059427241A251D003CA820 /* OutlinedButton.swift */; };
+		710E88B42421A6F60049D717 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E88B32421A6F60049D717 /* TodayViewModel.swift */; };
 		7114165A23EE904300FBFB7E /* RemoteConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7114165923EE904300FBFB7E /* RemoteConfigProvider.swift */; };
 		7114165C23EE95FE00FBFB7E /* RemoteConfigType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7114165B23EE95FE00FBFB7E /* RemoteConfigType.swift */; };
 		71536D5A23F16DC1004A330C /* RCPdfUrlEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71536D5923F16DC1004A330C /* RCPdfUrlEntity.swift */; };
@@ -163,6 +164,7 @@
 
 /* Begin PBXFileReference section */
 		71059427241A251D003CA820 /* OutlinedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlinedButton.swift; sourceTree = "<group>"; };
+		710E88B32421A6F60049D717 /* TodayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewModel.swift; sourceTree = "<group>"; };
 		7114165923EE904300FBFB7E /* RemoteConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigProvider.swift; sourceTree = "<group>"; };
 		7114165B23EE95FE00FBFB7E /* RemoteConfigType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigType.swift; sourceTree = "<group>"; };
 		71536D5923F16DC1004A330C /* RCPdfUrlEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCPdfUrlEntity.swift; sourceTree = "<group>"; };
@@ -314,6 +316,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		710E88B22421A6DE0049D717 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				710E88B32421A6F60049D717 /* TodayViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		7114165823EE84E600FBFB7E /* RemoteConfig */ = {
 			isa = PBXGroup;
 			children = (
@@ -422,6 +432,7 @@
 			children = (
 				715D9A662420C9740018F526 /* Model */,
 				715D9A572420A9360018F526 /* View */,
+				710E88B22421A6DE0049D717 /* ViewModel */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1192,6 +1203,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				710E88B42421A6F60049D717 /* TodayViewModel.swift in Sources */,
 				715D9A652420C61D0018F526 /* Configurations.swift in Sources */,
 				715D9A4A2420A8ED0018F526 /* TodayViewController.swift in Sources */,
 				715D9A682420C98C0018F526 /* TodayModel.swift in Sources */,

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		710E88B72421C06B0049D717 /* Configurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurations.swift; sourceTree = "<group>"; };
 		7114165923EE904300FBFB7E /* RemoteConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigProvider.swift; sourceTree = "<group>"; };
 		7114165B23EE95FE00FBFB7E /* RemoteConfigType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigType.swift; sourceTree = "<group>"; };
+		714E102124226E650094FD38 /* ChukyoBustimeDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChukyoBustimeDebug.entitlements; sourceTree = "<group>"; };
+		714E1022242270960094FD38 /* TodayDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TodayDebug.entitlements; sourceTree = "<group>"; };
 		71536D5923F16DC1004A330C /* RCPdfUrlEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCPdfUrlEntity.swift; sourceTree = "<group>"; };
 		71536D5D23F17604004A330C /* RootModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootModel.swift; sourceTree = "<group>"; };
 		71536D5F23F176D9004A330C /* PdfUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfUrl.swift; sourceTree = "<group>"; };
@@ -432,6 +434,7 @@
 			children = (
 				715D9A562420A91F0018F526 /* Application */,
 				715D9A582420A9460018F526 /* Configs */,
+				714E1022242270960094FD38 /* TodayDebug.entitlements */,
 				715D9A4E2420A8ED0018F526 /* Info.plist */,
 			);
 			path = Today;
@@ -932,6 +935,7 @@
 				A4B03E8C23DE7CB20069F7E8 /* Assets.xcassets */,
 				A4B03E8E23DE7CB20069F7E8 /* LaunchScreen.storyboard */,
 				71A32A5A23E05DE900EB7A55 /* DynamicFrameworks.xcfilelist */,
+				714E102124226E650094FD38 /* ChukyoBustimeDebug.entitlements */,
 				A4B03E9123DE7CB20069F7E8 /* Info.plist */,
 			);
 			path = ChukyoBustime;
@@ -1342,6 +1346,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = Today/TodayDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1594,6 +1599,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ChukyoBustime/ChukyoBustimeDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		715D9A5D2420AA400018F526 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B03EFD23DE8A960069F7E8 /* RxSwift.framework */; };
 		715D9A5E2420AA630018F526 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B4241F0E280087B373 /* Realm.framework */; };
 		715D9A602420AA630018F526 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B3241F0E280087B373 /* RealmSwift.framework */; };
+		715D9A632420BCCD0018F526 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A4B03E8C23DE7CB20069F7E8 /* Assets.xcassets */; };
+		715D9A652420C61D0018F526 /* Configurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A642420C61D0018F526 /* Configurations.swift */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -184,6 +186,7 @@
 		715D9A492420A8ED0018F526 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
 		715D9A4C2420A8ED0018F526 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		715D9A4E2420A8ED0018F526 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		715D9A642420C61D0018F526 /* Configurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurations.swift; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -430,6 +433,7 @@
 		715D9A582420A9460018F526 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
+				715D9A642420C61D0018F526 /* Configurations.swift */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -1066,6 +1070,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				715D9A632420BCCD0018F526 /* Assets.xcassets in Resources */,
 				715D9A4D2420A8ED0018F526 /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1174,6 +1179,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				715D9A652420C61D0018F526 /* Configurations.swift in Sources */,
 				715D9A4A2420A8ED0018F526 /* TodayViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -1297,10 +1297,11 @@
 		715D9A532420A8ED0018F526 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 7NJH5NAV4T;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1314,6 +1315,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1323,9 +1325,10 @@
 		715D9A542420A8ED0018F526 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7NJH5NAV4T;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1339,6 +1342,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1349,6 +1353,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71A32A5723E057E900EB7A55 /* Infra-Config.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
@@ -1387,6 +1392,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71A32A5823E0594F00EB7A55 /* Infra-Config.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
@@ -1424,6 +1430,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1485,6 +1492,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		71059428241A251D003CA820 /* OutlinedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71059427241A251D003CA820 /* OutlinedButton.swift */; };
 		710E88B42421A6F60049D717 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E88B32421A6F60049D717 /* TodayViewModel.swift */; };
+		710E88B82421C06B0049D717 /* Configurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E88B72421C06B0049D717 /* Configurations.swift */; };
 		7114165A23EE904300FBFB7E /* RemoteConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7114165923EE904300FBFB7E /* RemoteConfigProvider.swift */; };
 		7114165C23EE95FE00FBFB7E /* RemoteConfigType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7114165B23EE95FE00FBFB7E /* RemoteConfigType.swift */; };
 		71536D5A23F16DC1004A330C /* RCPdfUrlEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71536D5923F16DC1004A330C /* RCPdfUrlEntity.swift */; };
@@ -165,6 +166,7 @@
 /* Begin PBXFileReference section */
 		71059427241A251D003CA820 /* OutlinedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlinedButton.swift; sourceTree = "<group>"; };
 		710E88B32421A6F60049D717 /* TodayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewModel.swift; sourceTree = "<group>"; };
+		710E88B72421C06B0049D717 /* Configurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurations.swift; sourceTree = "<group>"; };
 		7114165923EE904300FBFB7E /* RemoteConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigProvider.swift; sourceTree = "<group>"; };
 		7114165B23EE95FE00FBFB7E /* RemoteConfigType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigType.swift; sourceTree = "<group>"; };
 		71536D5923F16DC1004A330C /* RCPdfUrlEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCPdfUrlEntity.swift; sourceTree = "<group>"; };
@@ -322,6 +324,14 @@
 				710E88B32421A6F60049D717 /* TodayViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		710E88B62421C0510049D717 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				710E88B72421C06B0049D717 /* Configurations.swift */,
+			);
+			path = Configs;
 			sourceTree = "<group>";
 		};
 		7114165823EE84E600FBFB7E /* RemoteConfig */ = {
@@ -496,10 +506,11 @@
 				71A32A6B23E083B500EB7A55 /* Entity */,
 				71A32A5D23E0835200EB7A55 /* Provider */,
 				A4AC23AB23E2D7320012439D /* Repository */,
-				71A329E523E04FB700EB7A55 /* Infra.h */,
-				71A329E623E04FB700EB7A55 /* Info.plist */,
+				710E88B62421C0510049D717 /* Configs */,
 				71A32A5723E057E900EB7A55 /* Infra-Config.debug.xcconfig */,
 				71A32A5823E0594F00EB7A55 /* Infra-Config.release.xcconfig */,
+				71A329E523E04FB700EB7A55 /* Infra.h */,
+				71A329E623E04FB700EB7A55 /* Info.plist */,
 			);
 			path = Infra;
 			sourceTree = "<group>";
@@ -1216,6 +1227,7 @@
 			files = (
 				715D9A38242086C80018F526 /* CollegeLocalCache.swift in Sources */,
 				A42D0DA223E112C400E95FED /* BusDateEntity.swift in Sources */,
+				710E88B82421C06B0049D717 /* Configurations.swift in Sources */,
 				71A32A6E23E083C800EB7A55 /* BusTimeEntity.swift in Sources */,
 				71536D5A23F16DC1004A330C /* RCPdfUrlEntity.swift in Sources */,
 				715D9A3D2420880C0018F526 /* LocalCacheRepository.swift in Sources */,

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		715D9A602420AA630018F526 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B3241F0E280087B373 /* RealmSwift.framework */; };
 		715D9A632420BCCD0018F526 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A4B03E8C23DE7CB20069F7E8 /* Assets.xcassets */; };
 		715D9A652420C61D0018F526 /* Configurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A642420C61D0018F526 /* Configurations.swift */; };
+		715D9A682420C98C0018F526 /* TodayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715D9A672420C98C0018F526 /* TodayModel.swift */; };
+		715D9A692420CED80018F526 /* SwiftDate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B03F0923DE9BBD0069F7E8 /* SwiftDate.framework */; };
 		717F0D7523EEFB6700354AC4 /* RemoteConfigError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */; };
 		71910BC123EB101E00132A7D /* ToCollegeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC023EB101E00132A7D /* ToCollegeModel.swift */; };
 		71910BC423EB116200132A7D /* ToCollegeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71910BC323EB116200132A7D /* ToCollegeViewModel.swift */; };
@@ -187,6 +189,7 @@
 		715D9A4C2420A8ED0018F526 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		715D9A4E2420A8ED0018F526 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		715D9A642420C61D0018F526 /* Configurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurations.swift; sourceTree = "<group>"; };
+		715D9A672420C98C0018F526 /* TodayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayModel.swift; sourceTree = "<group>"; };
 		717F0D7423EEFB6700354AC4 /* RemoteConfigError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigError.swift; sourceTree = "<group>"; };
 		71910BC023EB101E00132A7D /* ToCollegeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeModel.swift; sourceTree = "<group>"; };
 		71910BC323EB116200132A7D /* ToCollegeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToCollegeViewModel.swift; sourceTree = "<group>"; };
@@ -274,6 +277,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				715D9A5B2420AA400018F526 /* RxCocoa.framework in Frameworks */,
+				715D9A692420CED80018F526 /* SwiftDate.framework in Frameworks */,
 				715D9A5C2420AA400018F526 /* RxRelay.framework in Frameworks */,
 				715D9A5D2420AA400018F526 /* RxSwift.framework in Frameworks */,
 				715D9A472420A8ED0018F526 /* NotificationCenter.framework in Frameworks */,
@@ -416,6 +420,7 @@
 		715D9A562420A91F0018F526 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				715D9A662420C9740018F526 /* Model */,
 				715D9A572420A9360018F526 /* View */,
 			);
 			path = Application;
@@ -436,6 +441,14 @@
 				715D9A642420C61D0018F526 /* Configurations.swift */,
 			);
 			path = Configs;
+			sourceTree = "<group>";
+		};
+		715D9A662420C9740018F526 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				715D9A672420C98C0018F526 /* TodayModel.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		71910BBF23EB100300132A7D /* ToCollege */ = {
@@ -1181,6 +1194,7 @@
 			files = (
 				715D9A652420C61D0018F526 /* Configurations.swift in Sources */,
 				715D9A4A2420A8ED0018F526 /* TodayViewController.swift in Sources */,
+				715D9A682420C98C0018F526 /* TodayModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -1321,7 +1321,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1335,7 +1335,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime Today Extension development";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ChukyoBustime/Application/Model/ToCollege/ToCollegeModel.swift
+++ b/ChukyoBustime/Application/Model/ToCollege/ToCollegeModel.swift
@@ -35,22 +35,9 @@ class ToCollegeModelImpl: ToCollegeModel {
     
     // MARK: Firestore
     
-    /// 時刻表のデータをキャッシュもしくはFirestoreから取得する.
+    /// 時刻表のデータをFirestoreから取得する.
     /// - Parameter date: 取得するタイミングの`Date`.
     func getBusTimes(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
-        return localCacheRepository.checkCache(at: date, destination: .toCollege)
-            .flatMap {
-                $0 ? self.getBusTimesFromCache(at: date) : self.getBusTimesFromFirestore(at: date)
-            }
-    }
-    
-    private func getBusTimesFromCache(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
-        return localCacheRepository.loadCache(of: CollegeLocalCache.self)
-            .map { (busDate: $0.busDate ?? BusDateEntity(diagram: "UNKNOWN", diagramName: "UNKNOWN"), busTimes: Array($0.busTimes)) }
-            .translate(BusDateAndBusTimesTranslator()).debug()
-    }
-    
-    private func getBusTimesFromFirestore(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
         return firestoreRepository.getBusTimes(at: date, destination: .toCollege)
             .flatMap { value -> Single<(busDate: BusDate, busTimes: [BusTime])> in
                 // NOTE: キャッシュを保存して完了した後にFirestoreから取得したものを流す.

--- a/ChukyoBustime/Application/Model/ToStation/ToStationModel.swift
+++ b/ChukyoBustime/Application/Model/ToStation/ToStationModel.swift
@@ -47,7 +47,7 @@ class ToStationModelImpl: ToStationModel {
     private func getBusTimesFromCache(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
         return localCacheRepository.loadCache(of: StationLocalCache.self)
             .map { (busDate: $0.busDate ?? BusDateEntity(diagram: "UNKNOWN", diagramName: "UNKNOWN"), busTimes: Array($0.busTimes)) }
-            .translate(BusDateAndBusTimesTranslator()).debug()
+            .translate(BusDateAndBusTimesTranslator())
     }
     
     private func getBusTimesFromFirestore(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {

--- a/ChukyoBustime/Application/Model/ToStation/ToStationModel.swift
+++ b/ChukyoBustime/Application/Model/ToStation/ToStationModel.swift
@@ -35,22 +35,9 @@ class ToStationModelImpl: ToStationModel {
     
     // MARK: Firestore
     
-    /// 時刻表のデータをキャッシュもしくはFirestoreから取得する.
+    /// 時刻表のデータをFirestoreから取得する.
     /// - Parameter date: 取得するタイミングの`Date`.
     func getBusTimes(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
-        return localCacheRepository.checkCache(at: date, destination: .toStation)
-            .flatMap {
-                $0 ? self.getBusTimesFromCache(at: date) : self.getBusTimesFromFirestore(at: date)
-            }
-    }
-    
-    private func getBusTimesFromCache(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
-        return localCacheRepository.loadCache(of: StationLocalCache.self)
-            .map { (busDate: $0.busDate ?? BusDateEntity(diagram: "UNKNOWN", diagramName: "UNKNOWN"), busTimes: Array($0.busTimes)) }
-            .translate(BusDateAndBusTimesTranslator())
-    }
-    
-    private func getBusTimesFromFirestore(at date: Date) -> Single<(busDate: BusDate, busTimes: [BusTime])> {
         return firestoreRepository.getBusTimes(at: date, destination: .toStation)
             .flatMap { value -> Single<(busDate: BusDate, busTimes: [BusTime])> in
                 // NOTE: キャッシュを保存して完了した後にFirestoreから取得したものを流す.

--- a/ChukyoBustime/ChukyoBustimeDebug.entitlements
+++ b/ChukyoBustime/ChukyoBustimeDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.jp.shunya.yamada.ChukyoBustime</string>
+	</array>
+</dict>
+</plist>

--- a/ChukyoBustime/Info.plist
+++ b/ChukyoBustime/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>中京大学バス</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -12,12 +14,21 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundleDisplayName</key>
-	<string>中京大学バス</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sy-chukyo-bustime-app</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Infra/Configs/Configurations.swift
+++ b/Infra/Configs/Configurations.swift
@@ -1,0 +1,15 @@
+//
+//  Configurations.swift
+//  Infra
+//
+//  Created by 山田隼也 on 2020/03/18.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+
+enum Configurations {
+    // TODO: Setup app group.
+    /// AppGroup で設定した共有コンテナのURL
+    static let kAppGraoupURL: URL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "")!
+}

--- a/Infra/Configs/Configurations.swift
+++ b/Infra/Configs/Configurations.swift
@@ -11,5 +11,5 @@ import Foundation
 enum Configurations {
     // TODO: Setup app group.
     /// AppGroup で設定した共有コンテナのURL
-    static let kAppGraoupURL: URL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "")!
+    static let kAppGraoupURL: URL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.jp.shunya.yamada.ChukyoBustime")!
 }

--- a/Infra/Provider/Realm/RealmProvider.swift
+++ b/Infra/Provider/Realm/RealmProvider.swift
@@ -58,6 +58,7 @@ public final class RealmProvider: RealmProviderProtocol {
     private static func migrateIfNeeded() {
         let config = Realm.Configuration(schemaVersion: schemaVersion,
                                          deleteRealmIfMigrationNeeded: true)
+        //config.fileURL = Configurations.kAppGraoupURL.appendingPathComponent("defaul.realm")
         Realm.Configuration.defaultConfiguration = config
     }
     

--- a/Infra/Provider/Realm/RealmProvider.swift
+++ b/Infra/Provider/Realm/RealmProvider.swift
@@ -56,9 +56,9 @@ public final class RealmProvider: RealmProviderProtocol {
     // MARK: Private
     
     private static func migrateIfNeeded() {
-        let config = Realm.Configuration(schemaVersion: schemaVersion,
+        var config = Realm.Configuration(schemaVersion: schemaVersion,
                                          deleteRealmIfMigrationNeeded: true)
-        //config.fileURL = Configurations.kAppGraoupURL.appendingPathComponent("defaul.realm")
+        config.fileURL = Configurations.kAppGraoupURL.appendingPathComponent("defaul.realm")
         Realm.Configuration.defaultConfiguration = config
     }
     

--- a/Today/Application/Model/TodayModel.swift
+++ b/Today/Application/Model/TodayModel.swift
@@ -1,0 +1,59 @@
+//
+//  TodayModel.swift
+//  Today
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+import Infra
+import RxSwift
+import SwiftDate
+
+// MARK: - Interface
+
+protocol TodayModel {
+    func loadCache(at date: Date) -> Single<(college: String?, station: String?)>
+}
+
+// MARK: - Implementation
+
+struct TodayModelImpl: TodayModel {
+    
+    // MARK: Dependency
+    
+    private let repository: LocalCacheRepository
+    
+    // MARK: Initializer
+    
+    init(repository: LocalCacheRepository = LocalCacheRepositoryImpl()) {
+        self.repository = repository
+    }
+    
+    // MARK: Cache
+    
+    func loadCache(at date: Date) -> Single<(college: String?, station: String?)> {
+        return Single.zip(repository.loadCache(of: CollegeLocalCache.self), repository.loadCache(of: StationLocalCache.self))
+            .map { caches in
+                let now = DateInRegion(date, region: .current)
+                let second = now.hour * 3600 + now.minute * 60 + now.second
+                
+                let college: String?
+                let station: String?
+                
+                if let filteredCollege = caches.0.busTimes.first(where: { $0.second > second })?.second {
+                    college = String(format: "%02i:%02i", filteredCollege / 60 % 60, filteredCollege % 60)
+                } else {
+                    college = nil
+                }
+                if let filteredStation = caches.1.busTimes.first(where: { $0.second > second })?.second {
+                    station = String(format: "%02i:%02i", filteredStation / 60 % 60, filteredStation % 60)
+                } else {
+                    station = nil
+                }
+                
+                return (college: college, station: station)
+            }
+    }
+}

--- a/Today/Application/Model/TodayModel.swift
+++ b/Today/Application/Model/TodayModel.swift
@@ -42,13 +42,13 @@ struct TodayModelImpl: TodayModel {
                 let college: String?
                 let station: String?
                 
-                if let filteredCollege = caches.0.busTimes.first(where: { $0.second > second })?.second {
-                    college = String(format: "%02i:%02i", filteredCollege / 60 % 60, filteredCollege % 60)
+                if let filteredCollege = caches.0.busTimes.first(where: { $0.second > second }){
+                    college = String(format: "%02i:%02i", filteredCollege.hour, filteredCollege.minute)
                 } else {
                     college = nil
                 }
-                if let filteredStation = caches.1.busTimes.first(where: { $0.second > second })?.second {
-                    station = String(format: "%02i:%02i", filteredStation / 60 % 60, filteredStation % 60)
+                if let filteredStation = caches.1.busTimes.first(where: { $0.second > second }) {
+                    station = String(format: "%02i:%02i", filteredStation.hour, filteredStation.minute)
                 } else {
                     station = nil
                 }

--- a/Today/Application/View/Base.lproj/MainInterface.storyboard
+++ b/Today/Application/View/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" xcode11CocoaTouchSystemColor="labelColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="37"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Today/Application/View/Base.lproj/MainInterface.storyboard
+++ b/Today/Application/View/Base.lproj/MainInterface.storyboard
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,31 +11,84 @@
         <!--Today View Controller-->
         <scene sceneID="cwh-vc-ff4">
             <objects>
-                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModule="Today" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" xcode11CocoaTouchSystemColor="labelColor" cocoaTouchSystemColor="lightTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aqn-hH-EBv">
+                                <rect key="frame" x="8" y="52" width="304" height="50"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Widget Area" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TI5-bH-9QH">
+                                        <rect key="frame" x="0.0" y="0.0" width="304" height="0.0"/>
+                                        <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="14"/>
+                                        <color key="textColor" name="Primary"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dDw-c2-6h5">
+                                        <rect key="frame" x="0.0" y="4" width="304" height="46"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ODO-Z2-Zvn">
+                                                <rect key="frame" x="0.0" y="0.0" width="70" height="46"/>
+                                                <color key="backgroundColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="55o-mx-N7i">
+                                                <rect key="frame" x="78" y="0.0" width="70" height="46"/>
+                                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xiV-0i-qbi">
+                                                <rect key="frame" x="156" y="0.0" width="70" height="46"/>
+                                                <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cud-FS-wbO">
+                                                <rect key="frame" x="234" y="0.0" width="70" height="46"/>
+                                                <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                            <constraint firstItem="aqn-hH-EBv" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="ewq-Q2-yZK"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="aqn-hH-EBv" secondAttribute="bottom" constant="8" id="gjR-cm-BUQ"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="aqn-hH-EBv" secondAttribute="trailing" constant="8" id="oK2-Bq-8t3"/>
+                            <constraint firstItem="aqn-hH-EBv" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="vQM-QN-6vz"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="320" height="37"/>
+                    <size key="freeformSize" width="320" height="110"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="137.68115942028987" y="110.49107142857143"/>
         </scene>
     </scenes>
+    <resources>
+        <namedColor name="Primary">
+            <color red="0.035000000149011612" green="0.51800000667572021" blue="0.88999998569488525" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Today/Application/View/Base.lproj/MainInterface.storyboard
+++ b/Today/Application/View/Base.lproj/MainInterface.storyboard
@@ -22,14 +22,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pxc-ug-DgJ" userLabel="Line View">
-                                <rect key="frame" x="159.5" y="99.5" width="1" height="43"/>
+                                <rect key="frame" x="159.5" y="91.5" width="1" height="43"/>
                                 <color key="backgroundColor" name="Primary"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="1" id="E1M-cH-7GI"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aqn-hH-EBv">
-                                <rect key="frame" x="16" y="52" width="288" height="96"/>
+                                <rect key="frame" x="16" y="52" width="288" height="88"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="次のバス" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TI5-bH-9QH">
                                         <rect key="frame" x="0.0" y="0.0" width="288" height="16.5"/>
@@ -37,7 +37,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5rO-p9-TbI">
-                                        <rect key="frame" x="0.0" y="42" width="288" height="54"/>
+                                        <rect key="frame" x="0.0" y="34" width="288" height="54"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="1ky-rC-sLG">
                                                 <rect key="frame" x="0.0" y="0.0" width="114.5" height="54"/>
@@ -111,7 +111,7 @@
                             <constraint firstItem="Pxc-ug-DgJ" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="TiO-6J-xsO"/>
                             <constraint firstItem="Pxc-ug-DgJ" firstAttribute="centerY" secondItem="5rO-p9-TbI" secondAttribute="centerY" id="bX4-es-HhT"/>
                             <constraint firstItem="aqn-hH-EBv" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="16" id="ewq-Q2-yZK"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="aqn-hH-EBv" secondAttribute="bottom" constant="8" id="gjR-cm-BUQ"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="aqn-hH-EBv" secondAttribute="bottom" constant="16" id="gjR-cm-BUQ"/>
                             <constraint firstItem="Idl-iJ-tLn" firstAttribute="centerY" secondItem="S3S-Oj-5AN" secondAttribute="centerY" id="jaI-2x-AV5"/>
                             <constraint firstItem="Idl-iJ-tLn" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="jd7-Yr-w8p"/>
                             <constraint firstItem="Pxc-ug-DgJ" firstAttribute="height" secondItem="5rO-p9-TbI" secondAttribute="height" multiplier="0.8" id="mYb-x6-yrm"/>

--- a/Today/Application/View/Base.lproj/MainInterface.storyboard
+++ b/Today/Application/View/Base.lproj/MainInterface.storyboard
@@ -16,8 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="156"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Idl-iJ-tLn">
-                                <rect key="frame" x="142.5" y="68.5" width="35.5" height="19.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Idl-iJ-tLn">
+                                <rect key="frame" x="160" y="78" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="14"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/Today/Application/View/Base.lproj/MainInterface.storyboard
+++ b/Today/Application/View/Base.lproj/MainInterface.storyboard
@@ -22,10 +22,10 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pxc-ug-DgJ" userLabel="Line View">
-                                <rect key="frame" x="159.5" y="91.5" width="1" height="43"/>
+                                <rect key="frame" x="159" y="91.5" width="2" height="43"/>
                                 <color key="backgroundColor" name="Primary"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="1" id="E1M-cH-7GI"/>
+                                    <constraint firstAttribute="width" constant="2" id="E1M-cH-7GI"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aqn-hH-EBv">

--- a/Today/Application/View/Base.lproj/MainInterface.storyboard
+++ b/Today/Application/View/Base.lproj/MainInterface.storyboard
@@ -13,73 +13,124 @@
             <objects>
                 <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModule="Today" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="156"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aqn-hH-EBv">
-                                <rect key="frame" x="8" y="52" width="304" height="50"/>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Idl-iJ-tLn">
+                                <rect key="frame" x="142.5" y="68.5" width="35.5" height="19.5"/>
+                                <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="14"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pxc-ug-DgJ" userLabel="Line View">
+                                <rect key="frame" x="159.5" y="99.5" width="1" height="43"/>
+                                <color key="backgroundColor" name="Primary"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="1" id="E1M-cH-7GI"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aqn-hH-EBv">
+                                <rect key="frame" x="16" y="52" width="288" height="96"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Widget Area" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TI5-bH-9QH">
-                                        <rect key="frame" x="0.0" y="0.0" width="304" height="0.0"/>
-                                        <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="14"/>
-                                        <color key="textColor" name="Primary"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="次のバス" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TI5-bH-9QH">
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="16.5"/>
+                                        <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="12"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dDw-c2-6h5">
-                                        <rect key="frame" x="0.0" y="4" width="304" height="46"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5rO-p9-TbI">
+                                        <rect key="frame" x="0.0" y="42" width="288" height="54"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ODO-Z2-Zvn">
-                                                <rect key="frame" x="0.0" y="0.0" width="70" height="46"/>
-                                                <color key="backgroundColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="55o-mx-N7i">
-                                                <rect key="frame" x="78" y="0.0" width="70" height="46"/>
-                                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xiV-0i-qbi">
-                                                <rect key="frame" x="156" y="0.0" width="70" height="46"/>
-                                                <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cud-FS-wbO">
-                                                <rect key="frame" x="234" y="0.0" width="70" height="46"/>
-                                                <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="1ky-rC-sLG">
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="54"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_school" translatesAutoresizingMaskIntoConstraints="NO" id="JFF-cx-JE7">
+                                                        <rect key="frame" x="0.0" y="0.0" width="32" height="54"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="32" id="VdE-qH-GRN"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="RV6-5H-ip9">
+                                                        <rect key="frame" x="44" y="0.0" width="70.5" height="54"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 大学発" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ZF-d9-HFT">
+                                                                <rect key="frame" x="0.0" y="0.0" width="70.5" height="15.5"/>
+                                                                <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="11"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jh6-tF-1d9">
+                                                                <rect key="frame" x="0.0" y="15.5" width="70.5" height="38.5"/>
+                                                                <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="28"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="0TE-JR-6ye">
+                                                <rect key="frame" x="168.5" y="0.0" width="119.5" height="54"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_train" translatesAutoresizingMaskIntoConstraints="NO" id="Sp7-ap-AGO">
+                                                        <rect key="frame" x="0.0" y="0.0" width="32" height="54"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="32" id="ZTi-w4-kkh"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="PB3-RY-yIP">
+                                                        <rect key="frame" x="44" y="0.0" width="75.5" height="54"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 浄水駅発" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uf6-zK-ao0">
+                                                                <rect key="frame" x="0.0" y="0.0" width="75.5" height="15.5"/>
+                                                                <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="11"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bIZ-hW-tWR">
+                                                                <rect key="frame" x="0.0" y="15.5" width="75.5" height="38.5"/>
+                                                                <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="28"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lky-vS-3tH">
+                                <rect key="frame" x="0.0" y="44" width="320" height="112"/>
+                            </button>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="aqn-hH-EBv" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="ewq-Q2-yZK"/>
+                            <constraint firstItem="Lky-vS-3tH" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" id="8mr-fW-TqT"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="Lky-vS-3tH" secondAttribute="trailing" id="Eiw-Rp-luC"/>
+                            <constraint firstItem="Lky-vS-3tH" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" id="RXC-GW-SMW"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="Lky-vS-3tH" secondAttribute="bottom" id="TgO-zj-wOb"/>
+                            <constraint firstItem="Pxc-ug-DgJ" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="TiO-6J-xsO"/>
+                            <constraint firstItem="Pxc-ug-DgJ" firstAttribute="centerY" secondItem="5rO-p9-TbI" secondAttribute="centerY" id="bX4-es-HhT"/>
+                            <constraint firstItem="aqn-hH-EBv" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="16" id="ewq-Q2-yZK"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="aqn-hH-EBv" secondAttribute="bottom" constant="8" id="gjR-cm-BUQ"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="aqn-hH-EBv" secondAttribute="trailing" constant="8" id="oK2-Bq-8t3"/>
+                            <constraint firstItem="Idl-iJ-tLn" firstAttribute="centerY" secondItem="S3S-Oj-5AN" secondAttribute="centerY" id="jaI-2x-AV5"/>
+                            <constraint firstItem="Idl-iJ-tLn" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="jd7-Yr-w8p"/>
+                            <constraint firstItem="Pxc-ug-DgJ" firstAttribute="height" secondItem="5rO-p9-TbI" secondAttribute="height" multiplier="0.8" id="mYb-x6-yrm"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="aqn-hH-EBv" secondAttribute="trailing" constant="16" id="oK2-Bq-8t3"/>
                             <constraint firstItem="aqn-hH-EBv" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="vQM-QN-6vz"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="320" height="110"/>
+                    <size key="freeformSize" width="320" height="156"/>
+                    <connections>
+                        <outlet property="collegeTimeLabel" destination="jh6-tF-1d9" id="Rqs-gR-ULV"/>
+                        <outlet property="lineView" destination="Pxc-ug-DgJ" id="IGA-Ca-lvL"/>
+                        <outlet property="messageLabel" destination="Idl-iJ-tLn" id="CwD-AG-dgq"/>
+                        <outlet property="parentButton" destination="Lky-vS-3tH" id="rRd-Q6-aBX"/>
+                        <outlet property="parentStackView" destination="aqn-hH-EBv" id="9JC-ZR-QYZ"/>
+                        <outlet property="stationTimeLabel" destination="bIZ-hW-tWR" id="pNs-Cs-H4z"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -87,6 +138,8 @@
         </scene>
     </scenes>
     <resources>
+        <image name="ic_school" width="24" height="24"/>
+        <image name="ic_train" width="24" height="24"/>
         <namedColor name="Primary">
             <color red="0.035000000149011612" green="0.51800000667572021" blue="0.88999998569488525" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Today/Application/View/TodayViewController.swift
+++ b/Today/Application/View/TodayViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Infra
 import NotificationCenter
 
 class TodayViewController: UIViewController, NCWidgetProviding {

--- a/Today/Application/View/TodayViewController.swift
+++ b/Today/Application/View/TodayViewController.swift
@@ -7,14 +7,25 @@
 //
 
 import UIKit
-import Infra
 import NotificationCenter
 
-class TodayViewController: UIViewController, NCWidgetProviding {
+final class TodayViewController: UIViewController, NCWidgetProviding {
+    
+    // MARK: IBOutlet
+    
+    @IBOutlet private weak var parentButton: UIButton!
+    @IBOutlet private weak var parentStackView: UIStackView!
+    @IBOutlet private weak var collegeTimeLabel: UILabel!
+    @IBOutlet private weak var stationTimeLabel: UILabel!
+    @IBOutlet private weak var lineView: UIView!
+    @IBOutlet private weak var messageLabel: UILabel!
+    
+    // MARK: Lifecycle
         
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        setupParentStackViews()
+        setupMessageLabel()
     }
         
     func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
@@ -27,4 +38,40 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         completionHandler(NCUpdateResult.newData)
     }
     
+    // MARK: Tap event
+    
+    @objc
+    private func onTapParentButton(_ sender: UIButton) {
+        guard let url = URL(string: Configurations.kApplicationUrlScheme) else { return }
+        extensionContext?.open(url, completionHandler: nil)
+    }
+    
+}
+
+// MARK: - Setup
+
+extension TodayViewController {
+    
+    private func setupParentStackViews() {
+        parentButton.addTarget(self, action: #selector(onTapParentButton(_:)), for: .touchUpInside)
+        parentStackView.alpha = 0
+        lineView.alpha = 0
+    }
+    
+    private func setupMessageLabel() {
+        messageLabel.text = "データがありません。\nアプリを起動してデータを取得してください。"
+        //messageLabel.alpha = 0
+    }
+}
+
+// MARK: - Animation
+
+extension TodayViewController {
+    
+    private func showParentStackViewAnimation() {
+        UIView.animate(withDuration: 0.5) {
+            self.parentStackView.alpha = 1
+            self.lineView.alpha = 1
+        }
+    }
 }

--- a/Today/Application/View/TodayViewController.swift
+++ b/Today/Application/View/TodayViewController.swift
@@ -1,0 +1,29 @@
+//
+//  TodayViewController.swift
+//  Today
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import UIKit
+import NotificationCenter
+
+class TodayViewController: UIViewController, NCWidgetProviding {
+        
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+        
+    func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
+        // Perform any setup necessary in order to update the view.
+        
+        // If an error is encountered, use NCUpdateResult.Failed
+        // If there's no update required, use NCUpdateResult.NoData
+        // If there's an update, use NCUpdateResult.NewData
+        
+        completionHandler(NCUpdateResult.newData)
+    }
+    
+}

--- a/Today/Application/ViewModel/TodayViewModel.swift
+++ b/Today/Application/ViewModel/TodayViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  TodayViewModel.swift
+//  Today
+//
+//  Created by 山田隼也 on 2020/03/18.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class TodayViewModel {
+    
+    // MARK: Dependency
+    
+    private let model: TodayModel
+    
+    // MARK: Properties
+    
+    private let disposeBag = DisposeBag()
+    
+    // MARK: Initializer
+    
+    init(model: TodayModel = TodayModelImpl()) {
+        self.model = model
+    }
+}
+
+extension TodayViewModel {
+    
+    // MARK: I/O
+    
+    struct Input {
+        let widgetDidTap: Signal<Void>
+    }
+    
+    struct Output {
+        let isHiddenDriver: Driver<Bool>
+        let collegeDriver: Driver<String>
+        let stationDriver: Driver<String>
+        let messageDriver: Driver<String?>
+        let openApplicationSignal: Signal<Void>
+    }
+    
+    // MARK: Transform I/O
+    
+    func transform(_ input: TodayViewModel.Input) -> TodayViewModel.Output {
+        let isHiddenRelay: BehaviorRelay<Bool> = .init(value: true)
+        let collegeRelay: BehaviorRelay<String> = .init(value: "")
+        let stationRelay: BehaviorRelay<String> = .init(value: "")
+        let messageRealy: BehaviorRelay<String?> = .init(value: nil)
+        
+        // Model
+        let now = Date()
+        model.loadCache(at: now)
+            .subscribe(onSuccess: { caches in
+                let isHidden = caches.college == nil && caches.station == nil
+                isHiddenRelay.accept(isHidden)
+                messageRealy.accept(isHidden ? "データがありません。\nアプリを起動してデータを取得してください。" : nil)
+                
+                collegeRelay.accept(caches.college ?? "-")
+                stationRelay.accept(caches.station ?? "-")
+            }, onError: { error in
+                print(error)
+                messageRealy.accept("エラーが発生しました。")
+            })
+            .disposed(by: disposeBag)
+        
+        return Output(isHiddenDriver: isHiddenRelay.asDriver(),
+                      collegeDriver: collegeRelay.asDriver(),
+                      stationDriver: stationRelay.asDriver(),
+                      messageDriver: messageRealy.asDriver(),
+                      openApplicationSignal: input.widgetDidTap)
+    }
+}

--- a/Today/Configs/Configurations.swift
+++ b/Today/Configs/Configurations.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 enum Configurations {
-    static let kApplicationUrlScheme: String = "sy-chukyo-bustime-app://"
+    static let kApplicationUrlScheme: URL = URL(string: "sy-chukyo-bustime-app://")!
 }

--- a/Today/Configs/Configurations.swift
+++ b/Today/Configs/Configurations.swift
@@ -1,0 +1,13 @@
+//
+//  Configurations.swift
+//  Today
+//
+//  Created by 山田隼也 on 2020/03/17.
+//  Copyright © 2020 Shunya Yamada. All rights reserved.
+//
+
+import Foundation
+
+enum Configurations {
+    static let kApplicationUrlScheme: String = "sy-chukyo-bustime-app://"
+}

--- a/Today/Info.plist
+++ b/Today/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>中京大学バス</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Today/TodayDebug.entitlements
+++ b/Today/TodayDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.jp.shunya.yamada.ChukyoBustime</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 📝 詳細
**Today Extension** のターゲットを追加。  
ウィジェットからバスの時刻を確認できる機能を実装。  

ウィジェットとのデータのやりとりを行うため、  
Firestoreから取得したデータを端末にキャッシュとして持つように実装。  
ただしキャッシュはウィジェットから読み込みを行う際にのみ使用。  
理由として、**Firestore側のデータの修正が即時反映されるようにする**ため。  

## 🚧 注意  
**App Group** の設定、証明書は開発のみ行っているので  
リリース時にはリリース用の証明書等が必要。