### PR TITLE
🛠 カウントダウンが1時間以上の場合の表記を修正

### DIFF
--- a/ChukyoBustime/Application/ViewModel/Child/Countdown/CountdownViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/Child/Countdown/CountdownViewModel.swift
@@ -86,8 +86,8 @@ extension CountdownViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         let timerDriver = timerRelay
-            .map { $0 < 0 ? 0 : $0 } // NOTE: Map minus value to zero
-            .map { String(format: "%02i:%02i", $0 / 60 % 60, $0 % 60) }
+            .map { $0 < 0 ? 0 : $0 } // NOTE: 負の数は 0 として流す.
+            .map { $0 >= 216000 ? "60分以上" : String(format: "%02i:%02i", $0 / 60 % 60, $0 % 60) } // NOTE: 1時間以上なら 1時間以上 と表記する.
             .asDriver(onErrorDriveWith: .empty())
         let departureTimeDriver: Driver<String> = dependency.busTimesDriver
             .map { busTimes in

--- a/ChukyoBustime/Application/ViewModel/Child/Countdown/CountdownViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/Child/Countdown/CountdownViewModel.swift
@@ -87,7 +87,7 @@ extension CountdownViewModel: ViewModelType {
         
         let timerDriver = timerRelay
             .map { $0 < 0 ? 0 : $0 } // NOTE: 負の数は 0 として流す.
-            .map { $0 >= 216000 ? "60分以上" : String(format: "%02i:%02i", $0 / 60 % 60, $0 % 60) } // NOTE: 1時間以上なら 1時間以上 と表記する.
+            .map { $0 >= 21600 ? "60分以上" : String(format: "%02i:%02i", $0 / 60 % 60, $0 % 60) } // NOTE: 1時間以上なら 1時間以上 と表記する.
             .asDriver(onErrorDriveWith: .empty())
         let departureTimeDriver: Driver<String> = dependency.busTimesDriver
             .map { busTimes in


### PR DESCRIPTION
## 📝 修正
カウントダウンの時間が**1時間以上**の場合は、**60分以上**と表記するように修正。