### PR TITLE
🛠 Realm のバージョンを最新のものにアップデート

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "ReactiveX/RxSwift" "5.1.1"
 github "malcommac/SwiftDate" "6.1.0"
-github "realm/realm-cocoa" "v4.4.1"
+github "realm/realm-cocoa" "v5.2.0"


### PR DESCRIPTION
## 📝 詳細
**Realm** のバージョンを最新の 5.2.0 にアップデート。
もしかしたら #32 が改善されるかも。