### PR TITLE
🛠 ローカルにキャッシュを保存するロジックを修正

### DIFF
--- a/Infra/Repository/Cache/LocalCacheRepository.swift
+++ b/Infra/Repository/Cache/LocalCacheRepository.swift
@@ -48,10 +48,13 @@ public struct LocalCacheRepositoryImpl: LocalCacheRepository {
     ///   - busDate: 保存する`BusDateEntity`のオブジェクト.
     ///   - busTimes: 保存する`BusTimeEntity`のオブジェクト配列.
     private func overwriteStationLocalCache(date: Date, busDate: BusDateEntity, busTimes: [BusTimeEntity]) -> Completable {
+        // NOTE: デフォルトの `Date` は GMT で設定されているため、9時間ずれる.
+        // SwiftDate の `DateInRegion` で日本の日付にした上で YYYY-MM-dd のフォーマットにする.
+        let dateInRegion = DateInRegion(date, region: .current)
         return provider.get(StationLocalCache.self)
             .flatMapCompletable { object -> Completable in
                 // NOTE: 既にキャッシュを保存済みかどうかをチェック、正しくリレーションされているかどうかも確認
-                let newCache = StationLocalCache(lastUpdatedDate: date.toFormat("YYYY-MM-dd"), busDate: busDate, busTimes: busTimes)
+                let newCache = StationLocalCache(lastUpdatedDate: dateInRegion.toFormat("YYYY-MM-dd"), busDate: busDate, busTimes: busTimes)
                 guard let object = object,
                     let relatedBusDate = object.busDate else {
                     return self.provider.save(newCache)
@@ -71,10 +74,13 @@ public struct LocalCacheRepositoryImpl: LocalCacheRepository {
     ///   - busDate: 保存する`BusDateEntity`のオブジェクト.
     ///   - busTimes: 保存する`BusTimeEntity`のオブジェクト配列.
     private func overwriteCollegeLocalCache(date: Date, busDate: BusDateEntity, busTimes: [BusTimeEntity]) -> Completable {
+        // NOTE: デフォルトの `Date` は GMT で設定されているため、9時間ずれる.
+        // SwiftDate の `DateInRegion` で日本の日付にした上で YYYY-MM-dd のフォーマットにする.
+        let dateInRegion = DateInRegion(date, region: .current)
         return provider.get(CollegeLocalCache.self)
             .flatMapCompletable { object -> Completable in
                 // NOTE: 既にキャッシュを保存済みかどうかをチェック、正しくリレーションされているかどうかも確認
-                let newCache = CollegeLocalCache(lastUpdatedDate: date.toFormat("YYYY-MM-dd"), busDate: busDate, busTimes: busTimes)
+                let newCache = CollegeLocalCache(lastUpdatedDate: dateInRegion.toFormat("YYYY-MM-dd"), busDate: busDate, busTimes: busTimes)
                 guard let object = object,
                     let relatedBusDate = object.busDate else {
                         return self.provider.save(newCache)
@@ -96,18 +102,24 @@ public struct LocalCacheRepositoryImpl: LocalCacheRepository {
     }
     
     private func checkStationLocalCache(at date: Date) -> Single<Bool> {
+        // NOTE: デフォルトの `Date` は GMT で設定されているため、9時間ずれる.
+        // SwiftDate の `DateInRegion` で日本の日付にした上で YYYY-MM-dd のフォーマットにする.
+        let dateInRegion = DateInRegion(date, region: .current)
         return provider.get(StationLocalCache.self)
             .map { object -> Bool in
                 guard let object = object else { return false }
-                return object.lastUpdatedDate == date.toFormat("YYYY-MM-dd")
+                return object.lastUpdatedDate == dateInRegion.toFormat("YYYY-MM-dd")
             }
     }
     
     private func checkCollegeLocalCache(at date: Date) -> Single<Bool> {
+        // NOTE: デフォルトの `Date` は GMT で設定されているため、9時間ずれる.
+        // SwiftDate の `DateInRegion` で日本の日付にした上で YYYY-MM-dd のフォーマットにする.
+        let dateInRegion = DateInRegion(date, region: .current)
         return provider.get(CollegeLocalCache.self)
             .map { object -> Bool in
                 guard let object = object else { return false }
-                return object.lastUpdatedDate == date.toFormat("YYYY-MM-dd")
+                return object.lastUpdatedDate == dateInRegion.toFormat("YYYY-MM-dd")
             }
     }
     


### PR DESCRIPTION
## 📝 詳細
ローカルにキャッシュを保存する際に `Date` をそのまま `YYYY-MM-dd` の形式に変換して保存していたので、
`DateInRegion` で GTM から端末のリージョンに合わせた時間に変換してから `YYYY-MM-dd` にするように修正。

ウィジェットにデータが表示されなかったのはやはりリージョンの問題。
キャッシュに保存する際に `Date` を渡していたが、GTM 基準になっていたので時間がずれる。
なので**午前8時は前日のデータとしてキャッシュが保存され**、ウィジェットには「データがありません」と表示されていた。