### PR TITLE
🛠 ルート画面の ViewModel をリファクタリング

### DIFF
--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		A555CC7925CFB99B0064A295 /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5C25CFB9570064A295 /* RxSwift.xcframework */; };
 		A555CC7A25CFB99B0064A295 /* Realm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5B25CFB9570064A295 /* Realm.xcframework */; };
 		A555CC7B25CFB99B0064A295 /* RxRelay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5A25CFB9570064A295 /* RxRelay.xcframework */; };
+		A57F695A25CFE05B000D0528 /* ChukyoBustimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57F695925CFE05B000D0528 /* ChukyoBustimeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,6 +151,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 71A329E223E04FB700EB7A55;
 			remoteInfo = Infra;
+		};
+		A57F695C25CFE05B000D0528 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A4B03E7823DE7CAB0069F7E8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A4B03E7F23DE7CAB0069F7E8;
+			remoteInfo = ChukyoBustime;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -303,6 +311,9 @@
 		A555CC5D25CFB9570064A295 /* RealmSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RealmSwift.xcframework; path = Carthage/Build/RealmSwift.xcframework; sourceTree = "<group>"; };
 		A555CC5E25CFB9580064A295 /* RxTest.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxTest.xcframework; path = Carthage/Build/RxTest.xcframework; sourceTree = "<group>"; };
 		A555CC5F25CFB9580064A295 /* RxBlocking.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxBlocking.xcframework; path = Carthage/Build/RxBlocking.xcframework; sourceTree = "<group>"; };
+		A57F695725CFE05B000D0528 /* ChukyoBustimeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChukyoBustimeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A57F695925CFE05B000D0528 /* ChukyoBustimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChukyoBustimeTests.swift; sourceTree = "<group>"; };
+		A57F695B25CFE05B000D0528 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A5867D9224A4D15E0031799D /* ChukyoBustimeRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChukyoBustimeRelease.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -342,6 +353,13 @@
 				A555CC6225CFB9580064A295 /* RxCocoa.xcframework in Frameworks */,
 				A555CC6625CFB9580064A295 /* Realm.xcframework in Frameworks */,
 				A555CC6A25CFB9580064A295 /* RealmSwift.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A57F695425CFE05B000D0528 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -974,6 +992,7 @@
 				A4B03E8223DE7CAB0069F7E8 /* ChukyoBustime */,
 				71A329E423E04FB700EB7A55 /* Infra */,
 				715D9A482420A8ED0018F526 /* Today */,
+				A57F695825CFE05B000D0528 /* ChukyoBustimeTests */,
 				A4B03E8123DE7CAB0069F7E8 /* Products */,
 				A4B03EFC23DE8A960069F7E8 /* Frameworks */,
 			);
@@ -985,6 +1004,7 @@
 				A4B03E8023DE7CAB0069F7E8 /* ChukyoBustime.app */,
 				71A329E323E04FB700EB7A55 /* Infra.framework */,
 				715D9A452420A8ED0018F526 /* Today.appex */,
+				A57F695725CFE05B000D0528 /* ChukyoBustimeTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1052,6 +1072,15 @@
 				71A329D723DF0E4A00EB7A55 /* GoogleService-Info.plist */,
 			);
 			path = Resource;
+			sourceTree = "<group>";
+		};
+		A57F695825CFE05B000D0528 /* ChukyoBustimeTests */ = {
+			isa = PBXGroup;
+			children = (
+				A57F695925CFE05B000D0528 /* ChukyoBustimeTests.swift */,
+				A57F695B25CFE05B000D0528 /* Info.plist */,
+			);
+			path = ChukyoBustimeTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1127,13 +1156,31 @@
 			productReference = A4B03E8023DE7CAB0069F7E8 /* ChukyoBustime.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A57F695625CFE05B000D0528 /* ChukyoBustimeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A57F695E25CFE05B000D0528 /* Build configuration list for PBXNativeTarget "ChukyoBustimeTests" */;
+			buildPhases = (
+				A57F695325CFE05B000D0528 /* Sources */,
+				A57F695425CFE05B000D0528 /* Frameworks */,
+				A57F695525CFE05B000D0528 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A57F695D25CFE05B000D0528 /* PBXTargetDependency */,
+			);
+			name = ChukyoBustimeTests;
+			productName = ChukyoBustimeTests;
+			productReference = A57F695725CFE05B000D0528 /* ChukyoBustimeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		A4B03E7823DE7CAB0069F7E8 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1130;
+				LastSwiftUpdateCheck = 1220;
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Shunya Yamada";
 				TargetAttributes = {
@@ -1146,6 +1193,10 @@
 					};
 					A4B03E7F23DE7CAB0069F7E8 = {
 						CreatedOnToolsVersion = 11.3.1;
+					};
+					A57F695625CFE05B000D0528 = {
+						CreatedOnToolsVersion = 12.2;
+						TestTargetID = A4B03E7F23DE7CAB0069F7E8;
 					};
 				};
 			};
@@ -1166,6 +1217,7 @@
 				A4B03E7F23DE7CAB0069F7E8 /* ChukyoBustime */,
 				71A329E223E04FB700EB7A55 /* Infra */,
 				715D9A442420A8ED0018F526 /* Today */,
+				A57F695625CFE05B000D0528 /* ChukyoBustimeTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1208,6 +1260,13 @@
 				71536D7723F4216A004A330C /* SettingItemCell.xib in Resources */,
 				71536D7023F41B27004A330C /* SettingLabelCell.xib in Resources */,
 				A42D0DAF23E120C500E95FED /* DynamicFrameworks.xcfilelist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A57F695525CFE05B000D0528 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1358,6 +1417,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A57F695325CFE05B000D0528 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57F695A25CFE05B000D0528 /* ChukyoBustimeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1375,6 +1442,11 @@
 			isa = PBXTargetDependency;
 			target = 71A329E223E04FB700EB7A55 /* Infra */;
 			targetProxy = A511F04F24A4DFA300DDD4AC /* PBXContainerItemProxy */;
+		};
+		A57F695D25CFE05B000D0528 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A4B03E7F23DE7CAB0069F7E8 /* ChukyoBustime */;
+			targetProxy = A57F695C25CFE05B000D0528 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1717,6 +1789,51 @@
 			};
 			name = Release;
 		};
+		A57F695F25CFE05B000D0528 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 7NJH5NAV4T;
+				INFOPLIST_FILE = ChukyoBustimeTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ShunyaYamada.ChukyoBustimeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChukyoBustime.app/ChukyoBustime";
+			};
+			name = Debug;
+		};
+		A57F696025CFE05B000D0528 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7NJH5NAV4T;
+				INFOPLIST_FILE = ChukyoBustimeTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ShunyaYamada.ChukyoBustimeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChukyoBustime.app/ChukyoBustime";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1752,6 +1869,15 @@
 			buildConfigurations = (
 				A4B03E9523DE7CB20069F7E8 /* Debug */,
 				A4B03E9623DE7CB20069F7E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A57F695E25CFE05B000D0528 /* Build configuration list for PBXNativeTarget "ChukyoBustimeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A57F695F25CFE05B000D0528 /* Debug */,
+				A57F696025CFE05B000D0528 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -116,18 +116,16 @@
 		A555CC6025CFB9580064A295 /* SwiftDate.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5825CFB9570064A295 /* SwiftDate.xcframework */; };
 		A555CC6225CFB9580064A295 /* RxCocoa.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5925CFB9570064A295 /* RxCocoa.xcframework */; };
 		A555CC6425CFB9580064A295 /* RxRelay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5A25CFB9570064A295 /* RxRelay.xcframework */; };
-		A555CC6625CFB9580064A295 /* Realm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5B25CFB9570064A295 /* Realm.xcframework */; };
 		A555CC6825CFB9580064A295 /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5C25CFB9570064A295 /* RxSwift.xcframework */; };
 		A555CC6A25CFB9580064A295 /* RealmSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5D25CFB9570064A295 /* RealmSwift.xcframework */; };
-		A555CC6C25CFB9580064A295 /* RxTest.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5E25CFB9580064A295 /* RxTest.xcframework */; };
-		A555CC6E25CFB9580064A295 /* RxBlocking.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5F25CFB9580064A295 /* RxBlocking.xcframework */; };
 		A555CC7425CFB99B0064A295 /* SwiftDate.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5825CFB9570064A295 /* SwiftDate.xcframework */; };
 		A555CC7525CFB99B0064A295 /* RealmSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5D25CFB9570064A295 /* RealmSwift.xcframework */; };
 		A555CC7625CFB99B0064A295 /* RxCocoa.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5925CFB9570064A295 /* RxCocoa.xcframework */; };
 		A555CC7925CFB99B0064A295 /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5C25CFB9570064A295 /* RxSwift.xcframework */; };
-		A555CC7A25CFB99B0064A295 /* Realm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5B25CFB9570064A295 /* Realm.xcframework */; };
 		A555CC7B25CFB99B0064A295 /* RxRelay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A555CC5A25CFB9570064A295 /* RxRelay.xcframework */; };
 		A57F695A25CFE05B000D0528 /* ChukyoBustimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57F695925CFE05B000D0528 /* ChukyoBustimeTests.swift */; };
+		A5DA4A9325CFFFD100BC4F96 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B4241F0E280087B373 /* Realm.framework */; };
+		A5DA4A9425CFFFD200BC4F96 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D278B4241F0E280087B373 /* Realm.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -306,7 +304,6 @@
 		A555CC5825CFB9570064A295 /* SwiftDate.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftDate.xcframework; path = Carthage/Build/SwiftDate.xcframework; sourceTree = "<group>"; };
 		A555CC5925CFB9570064A295 /* RxCocoa.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxCocoa.xcframework; path = Carthage/Build/RxCocoa.xcframework; sourceTree = "<group>"; };
 		A555CC5A25CFB9570064A295 /* RxRelay.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxRelay.xcframework; path = Carthage/Build/RxRelay.xcframework; sourceTree = "<group>"; };
-		A555CC5B25CFB9570064A295 /* Realm.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Realm.xcframework; path = Carthage/Build/Realm.xcframework; sourceTree = "<group>"; };
 		A555CC5C25CFB9570064A295 /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 		A555CC5D25CFB9570064A295 /* RealmSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RealmSwift.xcframework; path = Carthage/Build/RealmSwift.xcframework; sourceTree = "<group>"; };
 		A555CC5E25CFB9580064A295 /* RxTest.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxTest.xcframework; path = Carthage/Build/RxTest.xcframework; sourceTree = "<group>"; };
@@ -331,12 +328,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5DA4A9425CFFFD200BC4F96 /* Realm.framework in Frameworks */,
 				A555CC7425CFB99B0064A295 /* SwiftDate.xcframework in Frameworks */,
 				A555CC7B25CFB99B0064A295 /* RxRelay.xcframework in Frameworks */,
 				A555CC7525CFB99B0064A295 /* RealmSwift.xcframework in Frameworks */,
 				A555CC7625CFB99B0064A295 /* RxCocoa.xcframework in Frameworks */,
 				A555CC7925CFB99B0064A295 /* RxSwift.xcframework in Frameworks */,
-				A555CC7A25CFB99B0064A295 /* Realm.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -344,14 +341,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5DA4A9325CFFFD100BC4F96 /* Realm.framework in Frameworks */,
 				71A329EA23E04FB700EB7A55 /* Infra.framework in Frameworks */,
-				A555CC6E25CFB9580064A295 /* RxBlocking.xcframework in Frameworks */,
 				A555CC6425CFB9580064A295 /* RxRelay.xcframework in Frameworks */,
 				A555CC6025CFB9580064A295 /* SwiftDate.xcframework in Frameworks */,
-				A555CC6C25CFB9580064A295 /* RxTest.xcframework in Frameworks */,
 				A555CC6825CFB9580064A295 /* RxSwift.xcframework in Frameworks */,
 				A555CC6225CFB9580064A295 /* RxCocoa.xcframework in Frameworks */,
-				A555CC6625CFB9580064A295 /* Realm.xcframework in Frameworks */,
 				A555CC6A25CFB9580064A295 /* RealmSwift.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1052,7 +1047,6 @@
 		A4B03EFC23DE8A960069F7E8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A555CC5B25CFB9570064A295 /* Realm.xcframework */,
 				A555CC5D25CFB9570064A295 /* RealmSwift.xcframework */,
 				A555CC5F25CFB9580064A295 /* RxBlocking.xcframework */,
 				A555CC5925CFB9570064A295 /* RxCocoa.xcframework */,
@@ -1142,6 +1136,7 @@
 				A4B03E7E23DE7CAB0069F7E8 /* Resources */,
 				A4B03EF023DE861E0069F7E8 /* Embed Frameworks */,
 				71A32A5923E05DA400EB7A55 /* Copy Dynamic Frameworks */,
+				A57F696425CFE616000D0528 /* Carthage */,
 				71FF5C1D23E1E8B400456D75 /* Crashlytics */,
 				715D9A522420A8ED0018F526 /* Embed App Extensions */,
 			);
@@ -1311,6 +1306,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
+		};
+		A57F696425CFE616000D0528 /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Realm.framework",
+			);
+			name = Carthage;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ChukyoBustime.xcodeproj/project.pbxproj
+++ b/ChukyoBustime.xcodeproj/project.pbxproj
@@ -1406,7 +1406,7 @@
 				CODE_SIGN_ENTITLEMENTS = Today/TodayDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1420,7 +1420,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime Today Extension development";
@@ -1437,7 +1437,7 @@
 				CODE_SIGN_ENTITLEMENTS = Today/TodayRelease.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1450,7 +1450,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime.Today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime Today Extension release";
@@ -1468,7 +1468,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1486,7 +1486,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = Shunya.yamada.Infra;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1508,7 +1508,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1526,7 +1526,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = Shunya.yamada.Infra;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1666,7 +1666,7 @@
 				CODE_SIGN_ENTITLEMENTS = ChukyoBustime/ChukyoBustimeDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1678,7 +1678,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime;
 				PRODUCT_NAME = ChukyoBustime;
 				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime iOS App Development";
@@ -1696,7 +1696,7 @@
 				CODE_SIGN_ENTITLEMENTS = ChukyoBustime/ChukyoBustimeRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution: Shunya Yamada (7NJH5NAV4T)";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7NJH5NAV4T;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1708,7 +1708,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shunya.yamada.ChukyoBustime;
 				PRODUCT_NAME = ChukyoBustime;
 				PROVISIONING_PROFILE_SPECIFIER = "ChukyoBustime iOS App Release";

--- a/ChukyoBustime.xcodeproj/xcshareddata/xcschemes/ChukyoBustime.xcscheme
+++ b/ChukyoBustime.xcodeproj/xcshareddata/xcschemes/ChukyoBustime.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A4B03E7F23DE7CAB0069F7E8"
+               BuildableName = "ChukyoBustime.app"
+               BlueprintName = "ChukyoBustime"
+               ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A57F695625CFE05B000D0528"
+               BuildableName = "ChukyoBustimeTests.xctest"
+               BlueprintName = "ChukyoBustimeTests"
+               ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A4B03E7F23DE7CAB0069F7E8"
+            BuildableName = "ChukyoBustime.app"
+            BlueprintName = "ChukyoBustime"
+            ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A4B03E7F23DE7CAB0069F7E8"
+            BuildableName = "ChukyoBustime.app"
+            BlueprintName = "ChukyoBustime"
+            ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ChukyoBustime.xcodeproj/xcshareddata/xcschemes/Today.xcscheme
+++ b/ChukyoBustime.xcodeproj/xcshareddata/xcschemes/Today.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "715D9A442420A8ED0018F526"
+               BuildableName = "Today.appex"
+               BlueprintName = "Today"
+               ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A4B03E7F23DE7CAB0069F7E8"
+               BuildableName = "ChukyoBustime.app"
+               BlueprintName = "ChukyoBustime"
+               ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A57F695625CFE05B000D0528"
+               BuildableName = "ChukyoBustimeTests.xctest"
+               BlueprintName = "ChukyoBustimeTests"
+               ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A4B03E7F23DE7CAB0069F7E8"
+            BuildableName = "ChukyoBustime.app"
+            BlueprintName = "ChukyoBustime"
+            ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A4B03E7F23DE7CAB0069F7E8"
+            BuildableName = "ChukyoBustime.app"
+            BlueprintName = "ChukyoBustime"
+            ReferencedContainer = "container:ChukyoBustime.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ChukyoBustime/Application/View/Root/RootViewController.swift
+++ b/ChukyoBustime/Application/View/Root/RootViewController.swift
@@ -11,11 +11,9 @@ import RxCocoa
 
 final class RootViewController: BaseViewController {
     
-    // MARK: IBOutlet
-    
     // MARK: Properties
     
-    private var viewModel: RootViewModel!
+    private let viewModel: RootViewModel = RootViewModel()
     
     // MARK: Lifecycle
     
@@ -25,7 +23,10 @@ final class RootViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         bindViewModel()
+        
+        viewModel.input.viewDidLoad()
     }
 }
 
@@ -34,14 +35,10 @@ final class RootViewController: BaseViewController {
 extension RootViewController {
     
     private func bindViewModel() {
-        let viewModel = RootViewModel()
-        self.viewModel = viewModel
-        
-        let input = RootViewModel.Input(viewDidAppear: rx.viewDidAppear.take(1).asSignal(onErrorSignalWith: .empty()))
-        let output = viewModel.transform(input: input)
-        
-        output.replaceRootToTabBar
-            .drive(onNext: { [weak self] in self?.replaceRootToTabBar() })
+        viewModel.output.replaceRootToTabBar
+            .emit(onNext: { [weak self] in
+                self?.replaceRootToTabBar()
+            })
             .disposed(by: disposeBag)
     }
 }

--- a/ChukyoBustime/Application/ViewModel/Root/RootViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/Root/RootViewModel.swift
@@ -18,8 +18,7 @@ protocol RootViewModelInputs {
 }
 
 protocol RootViewModelOutputs {
-    
-    /// Emits
+    /// Emits a void event to replace root to tab bar controller.
     var replaceRootToTabBar: Signal<Void> { get }
 }
 

--- a/ChukyoBustime/Application/ViewModel/Root/RootViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/Root/RootViewModel.swift
@@ -10,7 +10,27 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-final class RootViewModel {
+// MARK: - Protocols
+
+protocol RootViewModelInputs {
+    /// Call when the view did load..
+    func viewDidLoad()
+}
+
+protocol RootViewModelOutputs {
+    
+    /// Emits
+    var replaceRootToTabBar: Signal<Void> { get }
+}
+
+protocol RootViewModelType {
+    var input: RootViewModelInputs { get }
+    var output: RootViewModelOutputs { get }
+}
+
+// MARK: - ViewModel
+
+final class RootViewModel: RootViewModelInputs, RootViewModelOutputs {
     
     // MARK: Dependency
     
@@ -18,48 +38,34 @@ final class RootViewModel {
     
     // MARK: Properties
     
+    private let replaceRootToTabBarRelay: PublishRelay<Void>
     private let disposeBag = DisposeBag()
+    
+    var replaceRootToTabBar: Signal<Void> {
+        return replaceRootToTabBarRelay.asSignal()
+    }
     
     // MARK: Initializer
     
     init(model: RootModel = RootModelImpl()) {
         self.model = model
+        self.replaceRootToTabBarRelay = .init()
+    }
+    
+    // MARK: Inputs
+    
+    func viewDidLoad() {
+        model.fetchAndActivate()
+            .subscribe(onCompleted: { [weak self] in
+                self?.replaceRootToTabBarRelay.accept(())
+            }, onError: { error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
-extension RootViewModel: ViewModelType {
-    
-    // MARK: I/O
-    
-    struct Input {
-        let viewDidAppear: Signal<Void>
-    }
-    
-    struct Output {
-        let replaceRootToTabBar: Driver<Void>
-    }
-    
-    // MARK: Transform I/O
-    
-    func transform(input: RootViewModel.Input) -> RootViewModel.Output {
-        let replaceRootToTabBarRelay: PublishRelay<Void> = .init()
-        
-        input.viewDidAppear
-            .emit(onNext: { [weak self] in
-                guard let self = self else { return }
-                
-                // NOTE: Activate Firebase Remote Config values.
-                self.model.fetchAndActivate()
-                    .subscribe(onCompleted: {
-                        replaceRootToTabBarRelay.accept(())
-                    }, onError: { error in
-                        // TODO: Error handling.
-                        print(error)
-                    })
-                    .disposed(by: self.disposeBag)
-            })
-            .disposed(by: disposeBag)
-        
-        return Output(replaceRootToTabBar: replaceRootToTabBarRelay.asDriver(onErrorDriveWith: .empty()))
-    }
+extension RootViewModel: RootViewModelType {
+    var input: RootViewModelInputs { return self }
+    var output: RootViewModelOutputs { return self }
 }

--- a/ChukyoBustimeTests/ChukyoBustimeTests.swift
+++ b/ChukyoBustimeTests/ChukyoBustimeTests.swift
@@ -1,0 +1,26 @@
+//
+//  ChukyoBustimeTests.swift
+//  ChukyoBustimeTests
+//
+//  Created by Shunya Yamada on 2021/02/07.
+//  Copyright © 2021 Shunya Yamada. All rights reserved.
+//
+
+import XCTest
+
+class ChukyoBustimeTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+}

--- a/ChukyoBustimeTests/Info.plist
+++ b/ChukyoBustimeTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Infra/Entity/BusDate/BusDateEntity.swift
+++ b/Infra/Entity/BusDate/BusDateEntity.swift
@@ -23,8 +23,4 @@ public final class BusDateEntity: Object, Decodable {
         self.diagram = diagram
         self.diagramName = diagramName
     }
-    
-    public required override init() {
-        super.init()
-    }
 }

--- a/Infra/Entity/BusTime/BusTimeEntity.swift
+++ b/Infra/Entity/BusTime/BusTimeEntity.swift
@@ -52,8 +52,4 @@ public final class BusTimeEntity: Object, Decodable {
         self.isLast = isLast
         self.isKaizu = isKaizu
     }
-    
-    public required override init() {
-        super.init()
-    }
 }

--- a/Infra/Entity/Cache/CollegeLocalCache.swift
+++ b/Infra/Entity/Cache/CollegeLocalCache.swift
@@ -20,8 +20,4 @@ public final class CollegeLocalCache: Object, LocalCacheable {
         self.busDate = busDate
         self.busTimes = busTimes.reduce(List<BusTimeEntity>()) { $0.append($1); return $0 }
     }
-    
-    required override init() {
-        super.init()
-    }
 }

--- a/Infra/Entity/Cache/StationLocalCache.swift
+++ b/Infra/Entity/Cache/StationLocalCache.swift
@@ -20,8 +20,4 @@ public final class StationLocalCache: Object, LocalCacheable {
         self.busDate = busDate
         self.busTimes = busTimes.reduce(List<BusTimeEntity>()) { $0.append($1); return $0 }
     }
-    
-    required override init() {
-        super.init()
-    }
 }


### PR DESCRIPTION
## 📝 詳細

テストターゲットを追加したのはいいけど、Firebase がないと怒られたので、別 PR で対応予定。

### 実装

- `RootViewModel` を Kickstarter 方式にリファクタリング

### その他

- Xcode のビルドナンバーとバージョンをインクリメント
- Realm 関連でランタイムエラーが発生していたので、不要なイニシャライザーを削除
- 不要なテスト関連のフレームワーク( RxTest 等 )への依存が残っていたので削除