### PR TITLE
🛠 バックグラウンド復帰時の秒数の計算を修正

### DIFF
--- a/ChukyoBustime/Application/ViewModel/Child/Countdown/CountdownViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/Child/Countdown/CountdownViewModel.swift
@@ -76,7 +76,7 @@ final class CountdownViewModel: CountdownViewModelInputs, CountdownViewModelOutp
         
         timer = timerRelay
             .map { $0 < 0 ? 0 : $0 } // NOTE: 負の数は 0 として流す.
-            .map { $0 >= 21600 ? "60分以上" : String(format: "%02i:%02i", $0 / 60 % 60, $0 % 60) } // NOTE: 1時間以上なら 1時間以上 と表記する.
+            .map { $0 >= 3600 ? "60分以上" : String(format: "%02i:%02i", $0 / 60 % 60, $0 % 60) } // NOTE: 1時間以上なら 1時間以上 と表記する.
             .asDriver(onErrorDriveWith: .empty())
         arrivalTime = dependency.busTimes
             .map { busTimes in

--- a/ChukyoBustime/Application/ViewModel/ToCollege/ToCollegeViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/ToCollege/ToCollegeViewModel.swift
@@ -136,7 +136,7 @@ final class ToCollegeViewModel: ToCollegeViewModelInputs, ToCollegeViewModelOutp
     
     func willEnterForeground() {
         let now = DateInRegion(Date(), region: .current)
-        let second = now.hour * 3600 + now.minute + 60 + now.second
+        let second = now.hour * 3600 + now.minute * 60 + now.second
         let newArray = busTimesRelay.value.filter { $0.second >= second }
         busTimesRelay.accept(newArray)
     }

--- a/ChukyoBustime/Application/ViewModel/ToStation/ToStationViewModel.swift
+++ b/ChukyoBustime/Application/ViewModel/ToStation/ToStationViewModel.swift
@@ -136,7 +136,7 @@ final class ToStationViewModel: ToStationViewModelInputs, ToStationViewModelOutp
     
     func willEnterForeground() {
         let now = DateInRegion(Date(), region: .current)
-        let second = now.hour * 3600 + now.minute + 60 + now.second
+        let second = now.hour * 3600 + now.minute * 60 + now.second
         let newArray = busTimesRelay.value.filter { $0.second >= second }
         busTimesRelay.accept(newArray)
     }


### PR DESCRIPTION
## 📝 詳細

- バックグラウンド復帰時にバス一覧を現在の時刻のものに更新しているが、秒数の計算が間違っていたので修正。
- 1時間以上は画面にカウントダウンが出ないようにフィルタリングしていたが、フィルタリングの閾値が間違っていたので修正。

### TODO

- [x] 一旦シミュレーターで動作確認したい